### PR TITLE
SES SDK v1 → v2 마이그레이션

### DIFF
--- a/docs/plan/001-ses-v2-migration.md
+++ b/docs/plan/001-ses-v2-migration.md
@@ -1,0 +1,141 @@
+# 001-ses-v2-migration
+
+## 개요
+
+- **이슈**: [#1](https://github.com/Orchemi/my-resend/issues/1)
+- **브랜치**: `feat/1`
+- **상태**: 진행 중
+- **생성일**: 2026-04-26
+
+이 문서는 my-resend 가 사용하는 AWS SES SDK 를 v1 (`@aws-sdk/client-ses`) 에서 v2 (`@aws-sdk/client-sesv2`) 로 전환하는 작업의 단일 진실(single source of truth) 이다. DNS provider 추상화 (DigitalOcean / Route53) 는 본 트랙 범위 밖이며, SES SDK 전환이 끝난 뒤 별도 plan 으로 다룬다.
+
+## 배경
+
+my-resend 는 [eibrahim/freeresend](https://github.com/eibrahim/freeresend) 의 hard fork 이다 (분기 시점: 2026-04-26, 분기 base SHA `3439985`). 부모는 SES SDK **v1** 을 사용한다. SDK v2 로 전환하는 동기는 다음과 같다.
+
+- v2 의 `GetEmailIdentity` 는 verify 상태와 DKIM 속성을 한 번의 호출로 반환한다 — v1 에서 `GetIdentityVerificationAttributes` + `GetIdentityDkimAttributes` 두 호출로 나뉘었던 것이 통합된다.
+- v2 의 `CreateEmailIdentity` 는 identity 생성과 DKIM 활성화를 한 번에 처리할 수 있다.
+- v2 가 현재 AWS 권장 SDK 다. 신규 IAM policy 도 v2 액션 기준으로 작성하는 것이 자연스럽다.
+- my-resend 는 이미 upstream 에서 분기된 자체 OSS 이므로 SDK 마이그레이션 비용을 흡수할 수 있다.
+
+## 목표
+
+- [ ] 의존성 교체: `@aws-sdk/client-ses@^3.682` 제거 → `@aws-sdk/client-sesv2` 추가
+- [ ] `src/lib/ses.ts` 8개 함수를 v2 SDK 로 전면 리팩토링
+- [ ] `src/lib/__tests__/ses.test.ts` 신규 작성 (`aws-sdk-client-mock` 사용, 라이브 AWS 호출 없음)
+- [ ] consumer 회귀 검증: `src/lib/domains.ts`, `src/app/api/emails/route.ts`, `src/app/api/domains/[id]/retry-dns/route.ts`
+- [ ] `npm run lint && npm test && npm run build` 모두 통과
+- [ ] develop 으로 PR (1 커밋 rebase / 2+ 커밋 merge)
+
+## 설계
+
+### 접근 방식
+
+1. **외부 인터페이스 보존이 우선**. `sendEmail`, `verifyDomain`, `getDomainVerificationStatus`, `enableDomainDkim`, `getDomainDkimTokens`, `deleteDomainIdentity`, `createConfigurationSet`, `generateDNSRecords` 의 시그니처와 반환 형태(특히 `verifyDomain` 의 `{ verificationToken, status: "Pending" }`)는 **변경하지 않는다**. v2 SDK 호출은 함수 내부에 캡슐화한다 — consumer (`domains.ts` 등) 변경 0건 이 목표.
+2. **TDD**. 각 함수에 대해 `aws-sdk-client-mock` 으로 SESv2Client 의 send 를 가로채 입력·반환 매핑을 단위 테스트로 먼저 정의 → 함수 구현. 라이브 AWS 호출 없음.
+3. **`verifyDomain` 시맨틱 조정**. v1 `VerifyDomainIdentity` 는 verificationToken 을 반환했지만, v2 `CreateEmailIdentity` 는 반환하지 않는다. 후속으로 `GetEmailIdentity` 를 호출해 token 을 추출해야 한다 → 함수 내부에서 두 호출을 묶어 동일한 외부 반환 형태를 유지한다.
+4. **DKIM 활성화 단순화**. v1 은 `VerifyDomainDkimCommand` 로 별도 호출했지만, v2 의 `CreateEmailIdentityCommand` 는 `DkimSigningAttributes` 옵션으로 동시 활성화 가능. 다만 외부 인터페이스(`enableDomainDkim`) 는 유지하므로 함수는 `PutEmailIdentityDkimAttributesCommand` 로 매핑한다 (이미 존재하는 identity 가정).
+5. **`sendEmail` / `sendRawEmail` 통합 가능성 평가는 본 PR 범위 밖**. v2 의 `SendEmailCommand` 는 `Content.Simple | Content.Raw | Content.Template` 으로 통합되었지만, 본 PR 은 1:1 매핑만 수행한다. 통합 리팩토링은 후속.
+
+### 변경 범위
+
+```
+my-resend/
+├── package.json                              # @aws-sdk/client-ses 제거 + @aws-sdk/client-sesv2 추가
+├── package-lock.json                         # 자동 갱신
+├── src/lib/
+│   ├── ses.ts                                # 전면 리팩토링 (외부 시그니처 보존)
+│   └── __tests__/
+│       └── ses.test.ts                       # 신규 (aws-sdk-client-mock)
+└── docs/plan/
+    └── 001-ses-v2-migration.md               # 본 문서
+```
+
+**무변경**:
+- `src/lib/domains.ts` (소비자 — 인터페이스 보존 검증)
+- `src/app/api/emails/route.ts`
+- `src/app/api/domains/[id]/retry-dns/route.ts`
+- `src/lib/digitalocean.ts` (DNS 분리 작업과 직교)
+
+### v1 → v2 매핑
+
+| ses.ts 함수 | v1 command | v2 command | 키 변경 |
+|-------------|-----------|-----------|---------|
+| `sendEmail` | `SendEmailCommand` (`@aws-sdk/client-ses`) | `SendEmailCommand` (`@aws-sdk/client-sesv2`) | `Source` → `FromEmailAddress` · `Destination` 동일 · `Message.Subject/Body` → `Content.Simple.Subject/Body` · `Tags` → `EmailTags` · `ReplyToAddresses` 동일 |
+| `sendRawEmail` | `SendRawEmailCommand` | `SendEmailCommand` with `Content.Raw` | `Source`+`Destinations` → `FromEmailAddress`+`Destination.ToAddresses` · `RawMessage.Data` → `Content.Raw.Data` (Uint8Array 동일) |
+| `verifyDomain` | `VerifyDomainIdentityCommand` (returns token) | `CreateEmailIdentityCommand` + `GetEmailIdentityCommand` | identity 생성 후 별도 호출로 `VerificationStatus`/`DkimAttributes.Tokens` 조회. 외부 반환 `{ verificationToken, status: "Pending" }` 유지 |
+| `getDomainVerificationStatus` | `GetIdentityVerificationAttributesCommand` | `GetEmailIdentityCommand` | 응답 `VerificationStatus` (v2: `VerifiedForSendingStatus` boolean + `VerificationStatus` enum) → `"Pending"\|"Success"\|...` 문자열로 매핑 |
+| `enableDomainDkim` | `VerifyDomainDkimCommand` (returns tokens) | `PutEmailIdentityDkimAttributesCommand` + `GetEmailIdentityCommand` | DKIM signing 활성화 후 identity 조회로 토큰 추출 |
+| `getDomainDkimTokens` | `GetIdentityDkimAttributesCommand` | `GetEmailIdentityCommand` | `DkimAttributes.Tokens` 추출 |
+| `deleteDomainIdentity` | `DeleteIdentityCommand` | `DeleteEmailIdentityCommand` | 파라미터 `Identity` → `EmailIdentity` |
+| `createConfigurationSet` | `CreateConfigurationSetCommand` (input `ConfigurationSet: {Name}`) | `CreateConfigurationSetCommand` (input `ConfigurationSetName` top level) | 에러 처리(이미 존재) 분기 동일 — `AlreadyExistsException` 등 매칭 유지 |
+| `generateDNSRecords` | (SDK 무관, 순수 함수) | (변경 없음) | — |
+
+### 의사결정 기록
+
+| 결정 사항 | 선택지 | 결정 | 이유 |
+|-----------|--------|------|------|
+| 마이그레이션 단위 | A) 함수별 점진 / B) ses.ts 전체 한 번에 | **B** | 297라인 단일 모듈, 의존성도 단일 패키지 — 한 번에 swap 이 의미 단위. v1·v2 동시 의존은 안티패턴 |
+| Route53 + dns-provider 추상화 포함 여부 | A) 본 PR 통합 / B) 분리 | **B** | PR 크기·리뷰 단위 분리. SES v2 는 자체 검증 가능, Route53 은 IAM/Hosted Zone 등 추가 컨텍스트 필요 |
+| 외부 시그니처 변경 | A) 보존 / B) v2 신 API 노출 | **A** | consumer 변경 0건 목표. v2 의 통합 응답을 활용한 API 단순화는 후속 리팩토링 |
+| Mocking 라이브러리 | A) `aws-sdk-client-mock` / B) jest manual mock / C) 통합 테스트 | **A** | AWS v3 SDK 표준 mocking 라이브러리. 통합 테스트는 별도 단계 |
+| DKIM 활성화 시점 | A) `verifyDomain` 안에서 자동 활성화 / B) 별도 호출 유지 | **B** | upstream 설계 보존 — `enableDomainDkim` 가 별도 노출되어 있고 consumer 가 분기 호출 |
+| `sendEmail`/`sendRawEmail` 통합 | A) 본 PR 에서 통합 / B) 분리 유지 | **B** | v2 가 통합 가능하지만 본 PR 은 1:1 매핑만. 통합은 후속 리팩토링 (테스트 안전망 확보 후) |
+
+## 작업 단계
+
+### Phase 1: 의존성 교체 + 테스트 인프라
+
+- [ ] `npm uninstall @aws-sdk/client-ses && npm install @aws-sdk/client-sesv2` (peer/transitive 충돌 확인)
+- [ ] `npm install --save-dev aws-sdk-client-mock` (필요 시 `aws-sdk-client-mock-jest` 도)
+- [ ] `__tests__/ses.test.ts` 스텁 작성 (mock 셋업 + describe 골격)
+
+### Phase 2: TDD — 단순 매핑 함수부터
+
+- [ ] `deleteDomainIdentity`: 가장 단순 (1:1 매핑) — 테스트 + 구현
+- [ ] `createConfigurationSet`: 입력 키만 변경 + 기존 에러 분기 보존 검증 — 테스트 + 구현
+- [ ] `getDomainDkimTokens`: `GetEmailIdentity` 응답 매핑 — 테스트 + 구현
+- [ ] `getDomainVerificationStatus`: `GetEmailIdentity` 응답의 verification status enum 매핑 — 테스트 + 구현
+
+### Phase 3: TDD — 복합 매핑 함수
+
+- [ ] `verifyDomain`: `CreateEmailIdentity` + `GetEmailIdentity` 두 호출, 외부 반환 보존 — 테스트 + 구현
+- [ ] `enableDomainDkim`: `PutEmailIdentityDkimAttributes` + `GetEmailIdentity`, 토큰 배열 반환 — 테스트 + 구현
+
+### Phase 4: TDD — 메일 발송
+
+- [ ] `sendEmail`: simple content 매핑 + tags 매핑 + replyTo 보존 — 테스트 + 구현
+- [ ] `sendRawEmail`: raw content 매핑 + Uint8Array 보존 — 테스트 + 구현 (raw 빌더 자체는 무변경)
+
+### Phase 5: 회귀 검증
+
+- [ ] `domains.ts` 가 ses.ts import 한 함수들 호출하는 모든 위치 grep + TypeScript 컴파일 통과 확인
+- [ ] `src/app/api/emails/route.ts` 컴파일 + 응답 shape 변경 없음 확인
+- [ ] `src/app/api/domains/[id]/retry-dns/route.ts` 컴파일 확인
+- [ ] `npm run lint` 통과
+- [ ] `npm test` 전체 통과 (기존 waitlist/notifications/pricing-calculator 테스트 영향 없음)
+- [ ] `npm run build` (Next.js 빌드) 통과
+
+### Phase 6: 커밋 + PR
+
+- [ ] 영어 conventional 커밋 (이슈 번호 suffix 없음)
+  - 예시 분할:
+    - `feat(ses): migrate SES SDK from v1 to v2`
+    - `test(ses): add unit tests for v2 client commands`
+  - 또는 단일 커밋 `feat(ses): migrate SDK to v2 with unit tests` (1커밋 → rebase)
+- [ ] `gh pr create --base develop` (PR 본문에 본 plan + 이슈 #1 링크)
+- [ ] PR 머지 후 본 문서 상태 → "완료", 진행 로그에 PR 번호 기록
+
+## 진행 로그
+
+| 날짜 | 내용 | 비고 |
+|------|------|------|
+| 2026-04-26 | 이슈 #1 생성, `feat/1` 브랜치 생성, 본 plan 문서 작성 | |
+
+## 참고
+
+- AWS SESv2 API: <https://docs.aws.amazon.com/sesv2/latest/APIReference/Welcome.html>
+- AWS SESv2 SDK (JavaScript): <https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sesv2/>
+- aws-sdk-client-mock: <https://github.com/m-radzikowski/aws-sdk-client-mock>
+- 분기 base 커밋: `3439985c3d9f5dc187acc75d8a063d31c3d5fe9f` (tag `v0.1.0-my-resend`)
+- 원본 upstream: <https://github.com/eibrahim/freeresend>

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,12 @@ const customJestConfig = {
   transformIgnorePatterns: [
     'node_modules/(?!(nanoid)/)',
   ],
+  // sinon (transitive dep of aws-sdk-client-mock) ships an ESM entry via
+  // package.json `module` field that next/jest picks up but cannot transform.
+  // Force resolution to the CJS build for the test runtime.
+  moduleNameMapper: {
+    '^sinon$': '<rootDir>/node_modules/sinon/lib/sinon.js',
+  },
 }
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
-  "name": "freeresend",
-  "version": "1.0.0",
+  "name": "my-resend",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "freeresend",
-      "version": "1.0.0",
+      "name": "my-resend",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-iam": "^3.899.0",
-        "@aws-sdk/client-ses": "^3.682.0",
+        "@aws-sdk/client-sesv2": "^3.1037.0",
         "@types/pg": "^8.15.5",
         "axios": "^1.7.9",
         "bcryptjs": "^2.4.3",
@@ -42,6 +42,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/validator": "^13.12.2",
+        "aws-sdk-client-mock": "^4.1.0",
         "eslint": "^9",
         "eslint-config-next": "15.4.6",
         "jest": "^30.0.5",
@@ -719,442 +720,478 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-ses": {
-      "version": "3.864.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.864.0.tgz",
-      "integrity": "sha512-cmsOrJZsrNa892gD2cAsbVkweDulgmC8PE38cz//bM//1BW/R1MMFClapF+Q9gACtsRVTRBXNtsIsBq8Gm1Urw==",
+    "node_modules/@aws-sdk/client-sesv2": {
+      "version": "3.1037.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.1037.0.tgz",
+      "integrity": "sha512-4BbKwsg9rBhd7+fQosI+7b3uzY8IDWndIPCSqioOctuaoKrKQQ/lWlVvYJKOcI7U+fk6vJ5hg0eIuET/tQd8pQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.864.0",
-        "@aws-sdk/credential-provider-node": "3.864.0",
-        "@aws-sdk/middleware-host-header": "3.862.0",
-        "@aws-sdk/middleware-logger": "3.862.0",
-        "@aws-sdk/middleware-recursion-detection": "3.862.0",
-        "@aws-sdk/middleware-user-agent": "3.864.0",
-        "@aws-sdk/region-config-resolver": "3.862.0",
-        "@aws-sdk/types": "3.862.0",
-        "@aws-sdk/util-endpoints": "3.862.0",
-        "@aws-sdk/util-user-agent-browser": "3.862.0",
-        "@aws-sdk/util-user-agent-node": "3.864.0",
-        "@smithy/config-resolver": "^4.1.5",
-        "@smithy/core": "^3.8.0",
-        "@smithy/fetch-http-handler": "^5.1.1",
-        "@smithy/hash-node": "^4.0.5",
-        "@smithy/invalid-dependency": "^4.0.5",
-        "@smithy/middleware-content-length": "^4.0.5",
-        "@smithy/middleware-endpoint": "^4.1.18",
-        "@smithy/middleware-retry": "^4.1.19",
-        "@smithy/middleware-serde": "^4.0.9",
-        "@smithy/middleware-stack": "^4.0.5",
-        "@smithy/node-config-provider": "^4.1.4",
-        "@smithy/node-http-handler": "^4.1.1",
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/smithy-client": "^4.4.10",
-        "@smithy/types": "^4.3.2",
-        "@smithy/url-parser": "^4.0.5",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.26",
-        "@smithy/util-defaults-mode-node": "^4.0.26",
-        "@smithy/util-endpoints": "^3.0.7",
-        "@smithy/util-middleware": "^4.0.5",
-        "@smithy/util-retry": "^4.0.7",
-        "@smithy/util-utf8": "^4.0.0",
-        "@smithy/util-waiter": "^4.0.7",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/credential-provider-node": "^3.972.36",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.35",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.22",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.21",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.5",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.864.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.864.0.tgz",
-      "integrity": "sha512-THiOp0OpQROEKZ6IdDCDNNh3qnNn/kFFaTSOiugDpgcE5QdsOxh1/RXq7LmHpTJum3cmnFf8jG59PHcz9Tjnlw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.864.0",
-        "@aws-sdk/middleware-host-header": "3.862.0",
-        "@aws-sdk/middleware-logger": "3.862.0",
-        "@aws-sdk/middleware-recursion-detection": "3.862.0",
-        "@aws-sdk/middleware-user-agent": "3.864.0",
-        "@aws-sdk/region-config-resolver": "3.862.0",
-        "@aws-sdk/types": "3.862.0",
-        "@aws-sdk/util-endpoints": "3.862.0",
-        "@aws-sdk/util-user-agent-browser": "3.862.0",
-        "@aws-sdk/util-user-agent-node": "3.864.0",
-        "@smithy/config-resolver": "^4.1.5",
-        "@smithy/core": "^3.8.0",
-        "@smithy/fetch-http-handler": "^5.1.1",
-        "@smithy/hash-node": "^4.0.5",
-        "@smithy/invalid-dependency": "^4.0.5",
-        "@smithy/middleware-content-length": "^4.0.5",
-        "@smithy/middleware-endpoint": "^4.1.18",
-        "@smithy/middleware-retry": "^4.1.19",
-        "@smithy/middleware-serde": "^4.0.9",
-        "@smithy/middleware-stack": "^4.0.5",
-        "@smithy/node-config-provider": "^4.1.4",
-        "@smithy/node-http-handler": "^4.1.1",
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/smithy-client": "^4.4.10",
-        "@smithy/types": "^4.3.2",
-        "@smithy/url-parser": "^4.0.5",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.26",
-        "@smithy/util-defaults-mode-node": "^4.0.26",
-        "@smithy/util-endpoints": "^3.0.7",
-        "@smithy/util-middleware": "^4.0.5",
-        "@smithy/util-retry": "^4.0.7",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.864.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.864.0.tgz",
-      "integrity": "sha512-LFUREbobleHEln+Zf7IG83lAZwvHZG0stI7UU0CtwyuhQy5Yx0rKksHNOCmlM7MpTEbSCfntEhYi3jUaY5e5lg==",
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.5.tgz",
+      "integrity": "sha512-lMPlYlYfQdNZhlkJgnkmESwrY+hNh3PljmZ+37oAqLNdJ6rnILAwFSyc6B3bJeDOtMORNnMQIej0aTRuOlDyhQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.862.0",
-        "@aws-sdk/xml-builder": "3.862.0",
-        "@smithy/core": "^3.8.0",
-        "@smithy/node-config-provider": "^4.1.4",
-        "@smithy/property-provider": "^4.0.5",
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/signature-v4": "^5.1.3",
-        "@smithy/smithy-client": "^4.4.10",
-        "@smithy/types": "^4.3.2",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.5",
-        "@smithy/util-utf8": "^4.0.0",
-        "fast-xml-parser": "5.2.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.19",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.864.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.864.0.tgz",
-      "integrity": "sha512-StJPOI2Rt8UE6lYjXUpg6tqSZaM72xg46ljPg8kIevtBAAfdtq9K20qT/kSliWGIBocMFAv0g2mC0hAa+ECyvg==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.31.tgz",
+      "integrity": "sha512-X/yGB73LmDW/6MdDJGCDzZBUXnM3ys4vs9l+5ZTJmiEswDdP1OjeoAFlFjVGS9o4KB2wZWQ9KOfdVNSSK6Ep3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.864.0",
-        "@aws-sdk/types": "3.862.0",
-        "@smithy/property-provider": "^4.0.5",
-        "@smithy/types": "^4.3.2",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.864.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.864.0.tgz",
-      "integrity": "sha512-E/RFVxGTuGnuD+9pFPH2j4l6HvrXzPhmpL8H8nOoJUosjx7d4v93GJMbbl1v/fkDLqW9qN4Jx2cI6PAjohA6OA==",
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.33.tgz",
+      "integrity": "sha512-c0ZF+lwoWVvX5iCaGKL5T/4DnIw88CGqxA0BcBs3U86mIp5EZYPVg+KSPkMXOyokmADvNewiMUfSG2uFwjRp0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.864.0",
-        "@aws-sdk/types": "3.862.0",
-        "@smithy/fetch-http-handler": "^5.1.1",
-        "@smithy/node-http-handler": "^4.1.1",
-        "@smithy/property-provider": "^4.0.5",
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/smithy-client": "^4.4.10",
-        "@smithy/types": "^4.3.2",
-        "@smithy/util-stream": "^4.2.4",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.864.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.864.0.tgz",
-      "integrity": "sha512-PlxrijguR1gxyPd5EYam6OfWLarj2MJGf07DvCx9MAuQkw77HBnsu6+XbV8fQriFuoJVTBLn9ROhMr/ROAYfUg==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.35.tgz",
+      "integrity": "sha512-jsU4u/cRkKFLKQS0k918FQ27fzXLG5ENiLWQMYE6581zLeI2hWh04ptlrvZMB3wJT/5d+vSzJk74X1CMFr4y8Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.864.0",
-        "@aws-sdk/credential-provider-env": "3.864.0",
-        "@aws-sdk/credential-provider-http": "3.864.0",
-        "@aws-sdk/credential-provider-process": "3.864.0",
-        "@aws-sdk/credential-provider-sso": "3.864.0",
-        "@aws-sdk/credential-provider-web-identity": "3.864.0",
-        "@aws-sdk/nested-clients": "3.864.0",
-        "@aws-sdk/types": "3.862.0",
-        "@smithy/credential-provider-imds": "^4.0.7",
-        "@smithy/property-provider": "^4.0.5",
-        "@smithy/shared-ini-file-loader": "^4.0.5",
-        "@smithy/types": "^4.3.2",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/credential-provider-env": "^3.972.31",
+        "@aws-sdk/credential-provider-http": "^3.972.33",
+        "@aws-sdk/credential-provider-login": "^3.972.35",
+        "@aws-sdk/credential-provider-process": "^3.972.31",
+        "@aws-sdk/credential-provider-sso": "^3.972.35",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.35",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.35.tgz",
+      "integrity": "sha512-5oa3j0cA50jPqgNhZ9XdJVopuzUf1klRb28/2MfLYWWiPi9DRVvbrBWT+DidbHTT36520VuXZJahQwR+YgSjrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.864.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.864.0.tgz",
-      "integrity": "sha512-2BEymFeXURS+4jE9tP3vahPwbYRl0/1MVaFZcijj6pq+nf5EPGvkFillbdBRdc98ZI2NedZgSKu3gfZXgYdUhQ==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.36.tgz",
+      "integrity": "sha512-4nT2T8Z7vH8KE9EdjEsuIlHpZSlcaK2PrKbQBjuUGU46BCCzF3WvP0u0Uiosni3Ykmmn4rWLVawoOCLotUtCbg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.864.0",
-        "@aws-sdk/credential-provider-http": "3.864.0",
-        "@aws-sdk/credential-provider-ini": "3.864.0",
-        "@aws-sdk/credential-provider-process": "3.864.0",
-        "@aws-sdk/credential-provider-sso": "3.864.0",
-        "@aws-sdk/credential-provider-web-identity": "3.864.0",
-        "@aws-sdk/types": "3.862.0",
-        "@smithy/credential-provider-imds": "^4.0.7",
-        "@smithy/property-provider": "^4.0.5",
-        "@smithy/shared-ini-file-loader": "^4.0.5",
-        "@smithy/types": "^4.3.2",
+        "@aws-sdk/credential-provider-env": "^3.972.31",
+        "@aws-sdk/credential-provider-http": "^3.972.33",
+        "@aws-sdk/credential-provider-ini": "^3.972.35",
+        "@aws-sdk/credential-provider-process": "^3.972.31",
+        "@aws-sdk/credential-provider-sso": "^3.972.35",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.35",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.864.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.864.0.tgz",
-      "integrity": "sha512-Zxnn1hxhq7EOqXhVYgkF4rI9MnaO3+6bSg/tErnBQ3F8kDpA7CFU24G1YxwaJXp2X4aX3LwthefmSJHwcVP/2g==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.31.tgz",
+      "integrity": "sha512-eKeT4MXumpBJsrDLCYcSzIkFPVTFn/es7It2oogp2OhU/ic7P/+xzFpQx9ZhwtXS57Mc5S42BPWi7lHmvs/nYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.864.0",
-        "@aws-sdk/types": "3.862.0",
-        "@smithy/property-provider": "^4.0.5",
-        "@smithy/shared-ini-file-loader": "^4.0.5",
-        "@smithy/types": "^4.3.2",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.864.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.864.0.tgz",
-      "integrity": "sha512-UPyPNQbxDwHVGmgWdGg9/9yvzuedRQVF5jtMkmP565YX9pKZ8wYAcXhcYdNPWFvH0GYdB0crKOmvib+bmCuwkw==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.35.tgz",
+      "integrity": "sha512-bCuBdfnj0KGDMdLp6utMTLiJcFN2ek9EgZinxQZZSc3FxjJ/HSqeqab2cjbnoNfy8RM6suDCsRkmVY1izp9I+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.864.0",
-        "@aws-sdk/core": "3.864.0",
-        "@aws-sdk/token-providers": "3.864.0",
-        "@aws-sdk/types": "3.862.0",
-        "@smithy/property-provider": "^4.0.5",
-        "@smithy/shared-ini-file-loader": "^4.0.5",
-        "@smithy/types": "^4.3.2",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/token-providers": "3.1036.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.864.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.864.0.tgz",
-      "integrity": "sha512-nNcjPN4SYg8drLwqK0vgVeSvxeGQiD0FxOaT38mV2H8cu0C5NzpvA+14Xy+W6vT84dxgmJYKk71Cr5QL2Oz+rA==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.35.tgz",
+      "integrity": "sha512-swW6Bwvl8lanyEMtZOWE/oR6yqcRQH4HTQZUVsnDVgoXvRjRywpYpLv2BWwjUFyjPrqsdX6FeTkf4tMSe/qFTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.864.0",
-        "@aws-sdk/nested-clients": "3.864.0",
-        "@aws-sdk/types": "3.862.0",
-        "@smithy/property-provider": "^4.0.5",
-        "@smithy/types": "^4.3.2",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.862.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.862.0.tgz",
-      "integrity": "sha512-jDje8dCFeFHfuCAxMDXBs8hy8q9NCTlyK4ThyyfAj3U4Pixly2mmzY2u7b7AyGhWsjJNx8uhTjlYq5zkQPQCYw==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.862.0",
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/types": "^4.3.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.862.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.862.0.tgz",
-      "integrity": "sha512-N/bXSJznNBR/i7Ofmf9+gM6dx/SPBK09ZWLKsW5iQjqKxAKn/2DozlnE54uiEs1saHZWoNDRg69Ww4XYYSlG1Q==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.862.0",
-        "@smithy/types": "^4.3.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.862.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.862.0.tgz",
-      "integrity": "sha512-KVoo3IOzEkTq97YKM4uxZcYFSNnMkhW/qj22csofLegZi5fk90ztUnnaeKfaEJHfHp/tm1Y3uSoOXH45s++kKQ==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.862.0",
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/types": "^4.3.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.34.tgz",
+      "integrity": "sha512-/UL96JKjsjdodcRRMKl99tLQvK6Oi9ptLC9iU1yiTF/ruaDX0mtBBtnLNZDxIZRJOCVOtB49ed1YaTadqygk8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.864.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.864.0.tgz",
-      "integrity": "sha512-wrddonw4EyLNSNBrApzEhpSrDwJiNfjxDm5E+bn8n32BbAojXASH8W8jNpxz/jMgNkkJNxCfyqybGKzBX0OhbQ==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.35.tgz",
+      "integrity": "sha512-hOFWNOjVmOocpRlrU04nYxjMOeoe0Obu5AXEuhB8zblMCPl3cG1hdluQCZERRKFyhMQjwZnDbhSHjoMUjetFGw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.864.0",
-        "@aws-sdk/types": "3.862.0",
-        "@aws-sdk/util-endpoints": "3.862.0",
-        "@smithy/core": "^3.8.0",
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/types": "^4.3.2",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.4",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.864.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.864.0.tgz",
-      "integrity": "sha512-H1C+NjSmz2y8Tbgh7Yy89J20yD/hVyk15hNoZDbCYkXg0M358KS7KVIEYs8E2aPOCr1sK3HBE819D/yvdMgokA==",
+      "version": "3.997.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.3.tgz",
+      "integrity": "sha512-SivE6GP228IVgfsrr2c/vqTg95X0Qj39Yw4uIrcddpkUzIltNMoNOR62leHOLhODfjv9K8X2mPTwS69A5kT0nQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.864.0",
-        "@aws-sdk/middleware-host-header": "3.862.0",
-        "@aws-sdk/middleware-logger": "3.862.0",
-        "@aws-sdk/middleware-recursion-detection": "3.862.0",
-        "@aws-sdk/middleware-user-agent": "3.864.0",
-        "@aws-sdk/region-config-resolver": "3.862.0",
-        "@aws-sdk/types": "3.862.0",
-        "@aws-sdk/util-endpoints": "3.862.0",
-        "@aws-sdk/util-user-agent-browser": "3.862.0",
-        "@aws-sdk/util-user-agent-node": "3.864.0",
-        "@smithy/config-resolver": "^4.1.5",
-        "@smithy/core": "^3.8.0",
-        "@smithy/fetch-http-handler": "^5.1.1",
-        "@smithy/hash-node": "^4.0.5",
-        "@smithy/invalid-dependency": "^4.0.5",
-        "@smithy/middleware-content-length": "^4.0.5",
-        "@smithy/middleware-endpoint": "^4.1.18",
-        "@smithy/middleware-retry": "^4.1.19",
-        "@smithy/middleware-serde": "^4.0.9",
-        "@smithy/middleware-stack": "^4.0.5",
-        "@smithy/node-config-provider": "^4.1.4",
-        "@smithy/node-http-handler": "^4.1.1",
-        "@smithy/protocol-http": "^5.1.3",
-        "@smithy/smithy-client": "^4.4.10",
-        "@smithy/types": "^4.3.2",
-        "@smithy/url-parser": "^4.0.5",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.26",
-        "@smithy/util-defaults-mode-node": "^4.0.26",
-        "@smithy/util-endpoints": "^3.0.7",
-        "@smithy/util-middleware": "^4.0.5",
-        "@smithy/util-retry": "^4.0.7",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.35",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.22",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.21",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.5",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.862.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.862.0.tgz",
-      "integrity": "sha512-VisR+/HuVFICrBPY+q9novEiE4b3mvDofWqyvmxHcWM7HumTz9ZQSuEtnlB/92GVM3KDUrR9EmBHNRrfXYZkcQ==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.862.0",
-        "@smithy/node-config-provider": "^4.1.4",
-        "@smithy/types": "^4.3.2",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.22.tgz",
+      "integrity": "sha512-/rXhMXteD+BqhFd0nYprAgcZ/KtU+963uftPqd3tiFcFfooHZINXUGtOmo2SQjRVauCTNqIEzkwuSETdZFqTTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.34",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.864.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.864.0.tgz",
-      "integrity": "sha512-gTc2QHOBo05SCwVA65dUtnJC6QERvFaPiuppGDSxoF7O5AQNK0UR/kMSenwLqN8b5E1oLYvQTv3C1idJLRX0cg==",
+      "version": "3.1036.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1036.0.tgz",
+      "integrity": "sha512-aNSJ6jjDYayxN9ZA1JpycVScX93Lx03kKZ1EXt3DGOTahcWVLJj3oLAlop0xKP+vP2Ga2t49p1tEaMkTbCCaZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.864.0",
-        "@aws-sdk/nested-clients": "3.864.0",
-        "@aws-sdk/types": "3.862.0",
-        "@smithy/property-provider": "^4.0.5",
-        "@smithy/shared-ini-file-loader": "^4.0.5",
-        "@smithy/types": "^4.3.2",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.862.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
-      "integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.862.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.862.0.tgz",
-      "integrity": "sha512-eCZuScdE9MWWkHGM2BJxm726MCmWk/dlHjOKvkM0sN1zxBellBMw5JohNss1Z8/TUmnW2gb9XHTOiHuGjOdksA==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.862.0",
-        "@smithy/types": "^4.3.2",
-        "@smithy/url-parser": "^4.0.5",
-        "@smithy/util-endpoints": "^3.0.7",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
@@ -1170,31 +1207,32 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.862.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.862.0.tgz",
-      "integrity": "sha512-BmPTlm0r9/10MMr5ND9E92r8KMZbq5ltYXYpVcUbAsnB1RJ8ASJuRoLne5F7mB3YMx0FJoOTuSq7LdQM3LgW3Q==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.862.0",
-        "@smithy/types": "^4.3.2",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.864.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.864.0.tgz",
-      "integrity": "sha512-d+FjUm2eJEpP+FRpVR3z6KzMdx1qwxEYDz8jzNKwxYLBBquaBaP/wfoMtMQKAcbrR7aT9FZVZF7zDgzNxUvQlQ==",
+      "version": "3.973.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.21.tgz",
+      "integrity": "sha512-Av4UHTcAWgdvbN0IP9pbtf4Qa1+6LtJqQdZWj5pLn5J67w0pnJJAZZ+7JPPcj2KN3378zD2JDM9DwJKEyvyMTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.864.0",
-        "@aws-sdk/types": "3.862.0",
-        "@smithy/node-config-provider": "^4.1.4",
-        "@smithy/types": "^4.3.2",
+        "@aws-sdk/middleware-user-agent": "^3.972.35",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -1206,16 +1244,38 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.862.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.862.0.tgz",
-      "integrity": "sha512-6Ed0kmC1NMbuFTEgNmamAUU1h5gShgxL1hBVLbEzUa3trX5aJBz1vU4bXaBTvOYUAnOHtiy1Ml4AMStd6hJnFA==",
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.19.tgz",
+      "integrity": "sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
@@ -3367,6 +3427,18 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3489,6 +3561,27 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.3.tgz",
+      "integrity": "sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.0.tgz",
@@ -3503,15 +3596,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.3.0.tgz",
-      "integrity": "sha512-9oH+n8AVNiLPK/iK/agOsoWfrKZ3FGP3502tkksd6SRsKMYiu7AFX0YXo6YBADdsAj7C+G/aLKdsafIJHxuCkQ==",
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.0",
-        "@smithy/types": "^4.6.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3519,20 +3613,20 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.14.0.tgz",
-      "integrity": "sha512-XJ4z5FxvY/t0Dibms/+gLJrI5niRoY0BCmE02fwmPcRYFPI4KI876xaE79YGWIKnEslMbuQPsIEsoU/DXa0DoA==",
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.0",
-        "@smithy/types": "^4.6.0",
-        "@smithy/util-base64": "^4.2.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.0",
-        "@smithy/util-stream": "^4.4.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3540,15 +3634,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.0.tgz",
-      "integrity": "sha512-SOhFVvFH4D5HJZytb0bLKxCrSnwcqPiNlrw+S4ZXjMnsC+o9JcUQzbZOEQcA8yv9wJFNhfsUiIUKiEnYL68Big==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.0",
-        "@smithy/property-provider": "^4.2.0",
-        "@smithy/types": "^4.6.0",
-        "@smithy/url-parser": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3556,15 +3650,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.0.tgz",
-      "integrity": "sha512-BG3KSmsx9A//KyIfw+sqNmWFr1YBUr+TwpxFT7yPqAk0yyDh7oSNgzfNH7pS6OC099EGx2ltOULvumCFe8bcgw==",
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.0",
-        "@smithy/querystring-builder": "^4.2.0",
-        "@smithy/types": "^4.6.0",
-        "@smithy/util-base64": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3572,14 +3666,14 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.0.tgz",
-      "integrity": "sha512-ugv93gOhZGysTctZh9qdgng8B+xO0cj+zN0qAZ+Sgh7qTQGPOJbMdIuyP89KNfUyfAqFSNh5tMvC+h2uCpmTtA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.6.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3587,12 +3681,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.0.tgz",
-      "integrity": "sha512-ZmK5X5fUPAbtvRcUPtk28aqIClVhbfcmfoS4M7UQBTnDdrNxhsrxYVv0ZEl5NaPSyExsPWqL4GsPlRvtlwg+2A==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.6.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3600,9 +3694,9 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
-      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3612,13 +3706,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.0.tgz",
-      "integrity": "sha512-6ZAnwrXFecrA4kIDOcz6aLBhU5ih2is2NdcZtobBDSdSHtE9a+MThB5uqyK4XXesdOCvOcbCm2IGB95birTSOQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.0",
-        "@smithy/types": "^4.6.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3626,18 +3720,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.0.tgz",
-      "integrity": "sha512-jFVjuQeV8TkxaRlcCNg0GFVgg98tscsmIrIwRFeC74TIUyLE3jmY9xgc1WXrPQYRjQNK3aRoaIk6fhFRGOIoGw==",
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.14.0",
-        "@smithy/middleware-serde": "^4.2.0",
-        "@smithy/node-config-provider": "^4.3.0",
-        "@smithy/shared-ini-file-loader": "^4.3.0",
-        "@smithy/types": "^4.6.0",
-        "@smithy/url-parser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.0",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3645,19 +3739,20 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.0.tgz",
-      "integrity": "sha512-yaVBR0vQnOnzex45zZ8ZrPzUnX73eUC8kVFaAAbn04+6V7lPtxn56vZEBBAhgS/eqD6Zm86o6sJs6FuQVoX5qg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.5.tgz",
+      "integrity": "sha512-wnYOpB5vATFKWrY2Z9Alb0KhjZI6AbzU6Fbz3Hq2GnURdRYWB4q+qWivQtSTwXcmWUA3MZ6krfwL6Cq5MAbxsA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.0",
-        "@smithy/protocol-http": "^5.3.0",
-        "@smithy/service-error-classification": "^4.2.0",
-        "@smithy/smithy-client": "^4.7.0",
-        "@smithy/types": "^4.6.0",
-        "@smithy/util-middleware": "^4.2.0",
-        "@smithy/util-retry": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.3.0",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3665,13 +3760,14 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.0.tgz",
-      "integrity": "sha512-rpTQ7D65/EAbC6VydXlxjvbifTf4IH+sADKg6JmAvhkflJO2NvDeyU9qsWUNBelJiQFcXKejUHWRSdmpJmEmiw==",
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.0",
-        "@smithy/types": "^4.6.0",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3679,12 +3775,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.0.tgz",
-      "integrity": "sha512-G5CJ//eqRd9OARrQu9MK1H8fNm2sMtqFh6j8/rPozhEL+Dokpvi1Og+aCixTuwDAGZUkJPk6hJT5jchbk/WCyg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.6.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3692,14 +3788,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.0.tgz",
-      "integrity": "sha512-5QgHNuWdT9j9GwMPPJCKxy2KDxZ3E5l4M3/5TatSZrqYVoEiqQrDfAq8I6KWZw7RZOHtVtCzEPdYz7rHZixwcA==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.0",
-        "@smithy/shared-ini-file-loader": "^4.3.0",
-        "@smithy/types": "^4.6.0",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3707,15 +3803,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.3.0.tgz",
-      "integrity": "sha512-RHZ/uWCmSNZ8cneoWEVsVwMZBKy/8123hEpm57vgGXA3Irf/Ja4v9TVshHK2ML5/IqzAZn0WhINHOP9xl+Qy6Q==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.0",
-        "@smithy/querystring-builder": "^4.2.0",
-        "@smithy/types": "^4.6.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3723,12 +3818,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.0.tgz",
-      "integrity": "sha512-rV6wFre0BU6n/tx2Ztn5LdvEdNZ2FasQbPQmDOPfV9QQyDmsCkOAB0osQjotRCQg+nSKFmINhyda0D3AnjSBJw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.6.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3736,12 +3831,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.0.tgz",
-      "integrity": "sha512-6POSYlmDnsLKb7r1D3SVm7RaYW6H1vcNcTWGWrF7s9+2noNYvUsm7E4tz5ZQ9HXPmKn6Hb67pBDRIjrT4w/d7Q==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.6.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3749,13 +3844,13 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.0.tgz",
-      "integrity": "sha512-Q4oFD0ZmI8yJkiPPeGUITZj++4HHYCW3pYBYfIobUCkYpI6mbkzmG1MAQQ3lJYYWj3iNqfzOenUZu+jqdPQ16A==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.6.0",
-        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3763,12 +3858,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.0.tgz",
-      "integrity": "sha512-BjATSNNyvVbQxOOlKse0b0pSezTWGMvA87SvoFoFlkRsKXVsN3bEtjCxvsNXJXfnAzlWFPaT9DmhWy1vn0sNEA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.6.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3776,24 +3871,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.0.tgz",
-      "integrity": "sha512-Ylv1ttUeKatpR0wEOMnHf1hXMktPUMObDClSWl2TpCVT4DwtJhCeighLzSLbgH3jr5pBNM0LDXT5yYxUvZ9WpA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.0.tgz",
+      "integrity": "sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.6.0"
+        "@smithy/types": "^4.14.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.3.0.tgz",
-      "integrity": "sha512-VCUPPtNs+rKWlqqntX0CbVvWyjhmX30JCtzO+s5dlzzxrvSfRh5SY0yxnkirvc1c80vdKQttahL71a9EsdolSQ==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.6.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3801,18 +3896,18 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.0.tgz",
-      "integrity": "sha512-MKNyhXEs99xAZaFhm88h+3/V+tCRDQ+PrDzRqL0xdDpq4gjxcMmf5rBA3YXgqZqMZ/XwemZEurCBQMfxZOWq/g==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.0",
-        "@smithy/types": "^4.6.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.0",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3820,17 +3915,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.7.0.tgz",
-      "integrity": "sha512-3BDx/aCCPf+kkinYf5QQhdQ9UAGihgOVqI3QO5xQfSaIWvUE4KYLtiGRWsNe1SR7ijXC0QEPqofVp5Sb0zC8xQ==",
+      "version": "4.12.13",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.14.0",
-        "@smithy/middleware-endpoint": "^4.3.0",
-        "@smithy/middleware-stack": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.0",
-        "@smithy/types": "^4.6.0",
-        "@smithy/util-stream": "^4.4.0",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3838,9 +3933,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.6.0.tgz",
-      "integrity": "sha512-4lI9C8NzRPOv66FaY1LL1O/0v0aLVrq/mXP/keUa9mJOApEeae43LsLd2kZRUJw91gxOQfLIrV3OvqPgWz1YsA==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3850,13 +3945,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.0.tgz",
-      "integrity": "sha512-AlBmD6Idav2ugmoAL6UtR6ItS7jU5h5RNqLMZC7QrLCoITA9NzIN3nx9GWi8g4z1pfWh2r9r96SX/jHiNwPJ9A==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.0",
-        "@smithy/types": "^4.6.0",
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3864,13 +3959,13 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.2.0.tgz",
-      "integrity": "sha512-+erInz8WDv5KPe7xCsJCp+1WCjSbah9gWcmUXc9NqmhyPx59tf7jqFz+za1tRG1Y5KM1Cy1rWCcGypylFp4mvA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3878,9 +3973,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
-      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3890,9 +3985,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.0.tgz",
-      "integrity": "sha512-U8q1WsSZFjXijlD7a4wsDQOvOwV+72iHSfq1q7VD+V75xP/pdtm0WIGuaFJ3gcADDOKj2MIBn4+zisi140HEnQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3902,12 +3997,12 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
-      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3915,9 +4010,9 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
-      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3927,15 +4022,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.2.0.tgz",
-      "integrity": "sha512-qzHp7ZDk1Ba4LDwQVCNp90xPGqSu7kmL7y5toBpccuhi3AH7dcVBIT/pUxYcInK4jOy6FikrcTGq5wxcka8UaQ==",
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.0",
-        "@smithy/smithy-client": "^4.7.0",
-        "@smithy/types": "^4.6.0",
-        "bowser": "^2.11.0",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3943,17 +4037,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.0.tgz",
-      "integrity": "sha512-FxUHS3WXgx3bTWR6yQHNHHkQHZm/XKIi/CchTnKvBulN6obWpcbzJ6lDToXn+Wp0QlVKd7uYAz2/CTw1j7m+Kg==",
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.3.0",
-        "@smithy/credential-provider-imds": "^4.2.0",
-        "@smithy/node-config-provider": "^4.3.0",
-        "@smithy/property-provider": "^4.2.0",
-        "@smithy/smithy-client": "^4.7.0",
-        "@smithy/types": "^4.6.0",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3961,13 +4055,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.0.tgz",
-      "integrity": "sha512-TXeCn22D56vvWr/5xPqALc9oO+LN+QpFjrSM7peG/ckqEPoI3zaKZFp+bFwfmiHhn5MGWPaLCqDOJPPIixk9Wg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.0",
-        "@smithy/types": "^4.6.0",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3975,9 +4069,9 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3987,12 +4081,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.0.tgz",
-      "integrity": "sha512-u9OOfDa43MjagtJZ8AapJcmimP+K2Z7szXn8xbty4aza+7P1wjFmy2ewjSbhEiYQoW1unTlOAIV165weYAaowA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.6.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4000,13 +4094,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.0.tgz",
-      "integrity": "sha512-BWSiuGbwRnEE2SFfaAZEX0TqaxtvtSYPM/J73PFVm+A29Fg1HTPiYFb8TmX1DXp4hgcdyJcNQmprfd5foeORsg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.4.tgz",
+      "integrity": "sha512-FY1UQQ1VFmMwiYp1GVS4MeaGD5O0blLNYK0xCRHU+mJgeoH/hSY8Ld8sJWKQ6uznkh14HveRGQJncgPyNl9J+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.0",
-        "@smithy/types": "^4.6.0",
+        "@smithy/service-error-classification": "^4.3.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4014,18 +4108,18 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.4.0.tgz",
-      "integrity": "sha512-vtO7ktbixEcrVzMRmpQDnw/Ehr9UWjBvSJ9fyAbadKkC4w5Cm/4lMO8cHz8Ysb8uflvQUNRcuux/oNHKPXkffg==",
+      "version": "4.5.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.0",
-        "@smithy/node-http-handler": "^4.3.0",
-        "@smithy/types": "^4.6.0",
-        "@smithy/util-base64": "^4.2.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4033,9 +4127,9 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4045,12 +4139,12 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4072,9 +4166,9 @@
       }
     },
     "node_modules/@smithy/uuid": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
-      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4758,6 +4852,23 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.1.tgz",
+      "integrity": "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -5686,6 +5797,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/aws-sdk-client-mock": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-4.1.0.tgz",
+      "integrity": "sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinon": "^17.0.3",
+        "sinon": "^18.0.1",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/axe-core": {
       "version": "4.10.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
@@ -6518,6 +6641,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/doctrine": {
@@ -7387,6 +7520,21 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
     },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
@@ -9814,6 +9962,13 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/just-extend": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
+      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jwa": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
@@ -10648,6 +10803,29 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/nise": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-6.1.5.tgz",
+      "integrity": "sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^15.1.1",
+        "just-extend": "^6.2.0",
+        "path-to-regexp": "^8.3.0"
+      }
+    },
+    "node_modules/nise/node_modules/@sinonjs/fake-timers": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+      "integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -11038,6 +11216,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -11088,6 +11281,17 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/pg": {
       "version": "8.16.3",
@@ -12023,6 +12227,35 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "node_modules/sinon": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-18.0.1.tgz",
+      "integrity": "sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "11.2.2",
+        "@sinonjs/samsam": "^8.0.0",
+        "diff": "^5.2.0",
+        "nise": "^6.0.0",
+        "supports-color": "^7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/@sinonjs/fake-timers": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -12449,9 +12682,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
-      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-iam": "^3.899.0",
-    "@aws-sdk/client-ses": "^3.682.0",
+    "@aws-sdk/client-sesv2": "^3.1037.0",
     "@types/pg": "^8.15.5",
     "axios": "^1.7.9",
     "bcryptjs": "^2.4.3",
@@ -72,6 +72,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/validator": "^13.12.2",
+    "aws-sdk-client-mock": "^4.1.0",
     "eslint": "^9",
     "eslint-config-next": "15.4.6",
     "jest": "^30.0.5",

--- a/src/lib/__tests__/ses.test.ts
+++ b/src/lib/__tests__/ses.test.ts
@@ -1,0 +1,529 @@
+/**
+ * Unit tests for src/lib/ses.ts (SES SDK v2 wrapper).
+ *
+ * Strategy: aws-sdk-client-mock intercepts SESv2Client.send() calls so no
+ * live AWS request is ever made. Tests verify command input mapping (v1
+ * shape -> v2 shape) and response unwrapping (v2 shape -> v1-compatible
+ * external return shape preserved by ses.ts).
+ */
+import { TextDecoder } from "node:util";
+import { mockClient } from "aws-sdk-client-mock";
+import {
+  SESv2Client,
+  CreateConfigurationSetCommand,
+  CreateEmailIdentityCommand,
+  DeleteEmailIdentityCommand,
+  GetEmailIdentityCommand,
+  PutEmailIdentityDkimAttributesCommand,
+  SendEmailCommand,
+} from "@aws-sdk/client-sesv2";
+
+import {
+  createConfigurationSet,
+  deleteDomainIdentity,
+  enableDomainDkim,
+  getDomainDkimTokens,
+  getDomainVerificationStatus,
+  sendEmail,
+  sendRawEmail,
+  verifyDomain,
+} from "../ses";
+
+const sesMock = mockClient(SESv2Client);
+
+beforeEach(() => {
+  sesMock.reset();
+});
+
+describe("deleteDomainIdentity", () => {
+  it("issues DeleteEmailIdentityCommand with EmailIdentity = domain", async () => {
+    sesMock.on(DeleteEmailIdentityCommand).resolves({});
+
+    await deleteDomainIdentity("example.com");
+
+    const calls = sesMock.commandCalls(DeleteEmailIdentityCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args[0].input).toEqual({ EmailIdentity: "example.com" });
+  });
+
+  it("propagates AWS errors", async () => {
+    const err = new Error("not found");
+    sesMock.on(DeleteEmailIdentityCommand).rejects(err);
+
+    await expect(deleteDomainIdentity("nope.com")).rejects.toThrow("not found");
+  });
+});
+
+describe("createConfigurationSet", () => {
+  it("issues CreateConfigurationSetCommand with top-level ConfigurationSetName", async () => {
+    sesMock.on(CreateConfigurationSetCommand).resolves({});
+
+    const name = await createConfigurationSet("example.com");
+
+    expect(name).toBe("my-resend-example-com");
+    const calls = sesMock.commandCalls(CreateConfigurationSetCommand);
+    expect(calls).toHaveLength(1);
+    // v2 input: ConfigurationSetName at top level (not v1 ConfigurationSet:{Name})
+    expect(calls[0].args[0].input).toMatchObject({
+      ConfigurationSetName: "my-resend-example-com",
+    });
+    // Negative assertion: v1-style nested key must NOT be present
+    expect(
+      (calls[0].args[0].input as Record<string, unknown>).ConfigurationSet
+    ).toBeUndefined();
+  });
+
+  it("converts dots to dashes in config set name", async () => {
+    sesMock.on(CreateConfigurationSetCommand).resolves({});
+
+    const name = await createConfigurationSet("mail.example.com");
+
+    expect(name).toBe("my-resend-mail-example-com");
+  });
+
+  it("swallows AlreadyExistsException and still returns the name", async () => {
+    const err = Object.assign(new Error("exists"), {
+      name: "AlreadyExistsException",
+    });
+    sesMock.on(CreateConfigurationSetCommand).rejects(err);
+
+    const name = await createConfigurationSet("example.com");
+
+    expect(name).toBe("my-resend-example-com");
+  });
+
+  it("swallows ConfigurationSetAlreadyExistsException", async () => {
+    const err = Object.assign(new Error("exists"), {
+      name: "ConfigurationSetAlreadyExistsException",
+    });
+    sesMock.on(CreateConfigurationSetCommand).rejects(err);
+
+    await expect(createConfigurationSet("example.com")).resolves.toBe(
+      "my-resend-example-com"
+    );
+  });
+
+  it("swallows 409 http status code", async () => {
+    const err = Object.assign(new Error("conflict"), {
+      $metadata: { httpStatusCode: 409 },
+    });
+    sesMock.on(CreateConfigurationSetCommand).rejects(err);
+
+    await expect(createConfigurationSet("example.com")).resolves.toBe(
+      "my-resend-example-com"
+    );
+  });
+
+  it("rethrows unrelated errors", async () => {
+    const err = Object.assign(new Error("network down"), {
+      name: "NetworkingError",
+    });
+    sesMock.on(CreateConfigurationSetCommand).rejects(err);
+
+    await expect(createConfigurationSet("example.com")).rejects.toThrow(
+      "network down"
+    );
+  });
+});
+
+describe("getDomainDkimTokens", () => {
+  it("issues GetEmailIdentityCommand and extracts DkimAttributes.Tokens", async () => {
+    sesMock.on(GetEmailIdentityCommand).resolves({
+      DkimAttributes: {
+        Tokens: ["tokenA", "tokenB", "tokenC"],
+      },
+    });
+
+    const tokens = await getDomainDkimTokens("example.com");
+
+    expect(tokens).toEqual(["tokenA", "tokenB", "tokenC"]);
+    const calls = sesMock.commandCalls(GetEmailIdentityCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args[0].input).toEqual({ EmailIdentity: "example.com" });
+  });
+
+  it("returns [] when DkimAttributes is undefined", async () => {
+    sesMock.on(GetEmailIdentityCommand).resolves({});
+
+    const tokens = await getDomainDkimTokens("example.com");
+
+    expect(tokens).toEqual([]);
+  });
+
+  it("returns [] when Tokens is undefined", async () => {
+    sesMock.on(GetEmailIdentityCommand).resolves({
+      DkimAttributes: { SigningEnabled: false },
+    });
+
+    const tokens = await getDomainDkimTokens("example.com");
+
+    expect(tokens).toEqual([]);
+  });
+});
+
+describe("getDomainVerificationStatus", () => {
+  // Map v2 enum (UPPER_SNAKE) -> v1 PascalCase preserved by the wrapper.
+  const cases: Array<[string | undefined, string]> = [
+    ["PENDING", "Pending"],
+    ["SUCCESS", "Success"],
+    ["FAILED", "Failed"],
+    ["TEMPORARY_FAILURE", "TemporaryFailure"],
+    ["NOT_STARTED", "NotStarted"],
+    [undefined, "NotStarted"],
+  ];
+
+  it.each(cases)(
+    "maps v2 status %s to v1 status %s",
+    async (v2Status, expected) => {
+      sesMock.on(GetEmailIdentityCommand).resolves({
+        VerificationStatus: v2Status as
+          | "PENDING"
+          | "SUCCESS"
+          | "FAILED"
+          | "TEMPORARY_FAILURE"
+          | "NOT_STARTED"
+          | undefined,
+      });
+
+      const status = await getDomainVerificationStatus("example.com");
+
+      expect(status).toBe(expected);
+    }
+  );
+
+  it("issues GetEmailIdentityCommand with EmailIdentity (v2 key)", async () => {
+    sesMock.on(GetEmailIdentityCommand).resolves({
+      VerificationStatus: "SUCCESS",
+    });
+
+    await getDomainVerificationStatus("example.com");
+
+    const calls = sesMock.commandCalls(GetEmailIdentityCommand);
+    expect(calls[0].args[0].input).toEqual({ EmailIdentity: "example.com" });
+  });
+});
+
+describe("verifyDomain", () => {
+  it("creates identity then reads back tokens, preserving v1 return shape", async () => {
+    sesMock.on(CreateEmailIdentityCommand).resolves({});
+    sesMock.on(GetEmailIdentityCommand).resolves({
+      DkimAttributes: {
+        Tokens: ["tok1", "tok2", "tok3"],
+      },
+      VerificationStatus: "PENDING",
+    });
+
+    const result = await verifyDomain("example.com");
+
+    // External shape preserved: { verificationToken, status: "Pending" }
+    expect(result).toEqual({
+      verificationToken: "tok1",
+      status: "Pending",
+    });
+
+    const createCalls = sesMock.commandCalls(CreateEmailIdentityCommand);
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0].args[0].input).toEqual({
+      EmailIdentity: "example.com",
+    });
+
+    const getCalls = sesMock.commandCalls(GetEmailIdentityCommand);
+    expect(getCalls).toHaveLength(1);
+    expect(getCalls[0].args[0].input).toEqual({ EmailIdentity: "example.com" });
+  });
+
+  it("falls through to GetEmailIdentity when AlreadyExistsException is thrown", async () => {
+    const exists = Object.assign(new Error("identity exists"), {
+      name: "AlreadyExistsException",
+    });
+    sesMock.on(CreateEmailIdentityCommand).rejects(exists);
+    sesMock.on(GetEmailIdentityCommand).resolves({
+      DkimAttributes: { Tokens: ["existing-token"] },
+    });
+
+    const result = await verifyDomain("example.com");
+
+    expect(result.verificationToken).toBe("existing-token");
+    expect(result.status).toBe("Pending");
+  });
+
+  it("rethrows non-AlreadyExists errors from CreateEmailIdentity", async () => {
+    const err = Object.assign(new Error("limit exceeded"), {
+      name: "LimitExceededException",
+    });
+    sesMock.on(CreateEmailIdentityCommand).rejects(err);
+
+    await expect(verifyDomain("example.com")).rejects.toThrow("limit exceeded");
+    // Get must not be called when create rejects with unrelated error
+    expect(sesMock.commandCalls(GetEmailIdentityCommand)).toHaveLength(0);
+  });
+
+  it("returns empty verificationToken when no DKIM tokens are present", async () => {
+    sesMock.on(CreateEmailIdentityCommand).resolves({});
+    sesMock.on(GetEmailIdentityCommand).resolves({});
+
+    const result = await verifyDomain("example.com");
+
+    expect(result.verificationToken).toBe("");
+    expect(result.status).toBe("Pending");
+  });
+});
+
+describe("enableDomainDkim", () => {
+  it("calls Put then Get and returns DKIM tokens array", async () => {
+    sesMock.on(PutEmailIdentityDkimAttributesCommand).resolves({});
+    sesMock.on(GetEmailIdentityCommand).resolves({
+      DkimAttributes: { Tokens: ["k1", "k2", "k3"] },
+    });
+
+    const tokens = await enableDomainDkim("example.com");
+
+    expect(tokens).toEqual(["k1", "k2", "k3"]);
+
+    const putCalls = sesMock.commandCalls(PutEmailIdentityDkimAttributesCommand);
+    expect(putCalls).toHaveLength(1);
+    expect(putCalls[0].args[0].input).toEqual({
+      EmailIdentity: "example.com",
+      SigningEnabled: true,
+    });
+
+    const getCalls = sesMock.commandCalls(GetEmailIdentityCommand);
+    expect(getCalls).toHaveLength(1);
+    expect(getCalls[0].args[0].input).toEqual({ EmailIdentity: "example.com" });
+  });
+
+  it("returns [] when Get response has no Tokens", async () => {
+    sesMock.on(PutEmailIdentityDkimAttributesCommand).resolves({});
+    sesMock.on(GetEmailIdentityCommand).resolves({});
+
+    const tokens = await enableDomainDkim("example.com");
+
+    expect(tokens).toEqual([]);
+  });
+
+  it("propagates errors from PutEmailIdentityDkimAttributes", async () => {
+    sesMock
+      .on(PutEmailIdentityDkimAttributesCommand)
+      .rejects(new Error("not authorized"));
+
+    await expect(enableDomainDkim("example.com")).rejects.toThrow(
+      "not authorized"
+    );
+    // Get must not be called when Put rejects
+    expect(sesMock.commandCalls(GetEmailIdentityCommand)).toHaveLength(0);
+  });
+});
+
+describe("sendEmail (Simple content)", () => {
+  it("maps options to v2 SendEmailCommand input (FromEmailAddress / Content.Simple / EmailTags)", async () => {
+    sesMock.on(SendEmailCommand).resolves({ MessageId: "msg-abc" });
+
+    const id = await sendEmail({
+      from: "no-reply@example.com",
+      to: ["alice@x.com", "bob@y.com"],
+      cc: ["cc1@z.com"],
+      bcc: ["bcc1@z.com"],
+      subject: "Hello",
+      html: "<p>hi</p>",
+      text: "hi",
+      replyTo: ["reply@example.com"],
+      tags: { type: "test", env: "ci" },
+    });
+
+    expect(id).toBe("msg-abc");
+
+    const calls = sesMock.commandCalls(SendEmailCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0].args[0].input;
+
+    expect(input).toMatchObject({
+      FromEmailAddress: "no-reply@example.com",
+      Destination: {
+        ToAddresses: ["alice@x.com", "bob@y.com"],
+        CcAddresses: ["cc1@z.com"],
+        BccAddresses: ["bcc1@z.com"],
+      },
+      ReplyToAddresses: ["reply@example.com"],
+      Content: {
+        Simple: {
+          Subject: { Data: "Hello", Charset: "UTF-8" },
+          Body: {
+            Html: { Data: "<p>hi</p>", Charset: "UTF-8" },
+            Text: { Data: "hi", Charset: "UTF-8" },
+          },
+        },
+      },
+      EmailTags: [
+        { Name: "type", Value: "test" },
+        { Name: "env", Value: "ci" },
+      ],
+    });
+
+    // v1 keys must NOT leak through
+    const inputAsRecord = input as Record<string, unknown>;
+    expect(inputAsRecord.Source).toBeUndefined();
+    expect(inputAsRecord.Message).toBeUndefined();
+    expect(inputAsRecord.Tags).toBeUndefined();
+  });
+
+  it("omits Html when only text is provided", async () => {
+    sesMock.on(SendEmailCommand).resolves({ MessageId: "msg-1" });
+
+    await sendEmail({
+      from: "from@x.com",
+      to: ["to@x.com"],
+      subject: "S",
+      text: "T",
+    });
+
+    const input = sesMock.commandCalls(SendEmailCommand)[0].args[0].input;
+    expect(input.Content?.Simple?.Body?.Html).toBeUndefined();
+    expect(input.Content?.Simple?.Body?.Text).toEqual({
+      Data: "T",
+      Charset: "UTF-8",
+    });
+  });
+
+  it("omits Text when only html is provided", async () => {
+    sesMock.on(SendEmailCommand).resolves({ MessageId: "msg-1" });
+
+    await sendEmail({
+      from: "from@x.com",
+      to: ["to@x.com"],
+      subject: "S",
+      html: "<b>H</b>",
+    });
+
+    const input = sesMock.commandCalls(SendEmailCommand)[0].args[0].input;
+    expect(input.Content?.Simple?.Body?.Text).toBeUndefined();
+    expect(input.Content?.Simple?.Body?.Html).toEqual({
+      Data: "<b>H</b>",
+      Charset: "UTF-8",
+    });
+  });
+
+  it("omits EmailTags when no tags supplied", async () => {
+    sesMock.on(SendEmailCommand).resolves({ MessageId: "msg-1" });
+
+    await sendEmail({
+      from: "from@x.com",
+      to: ["to@x.com"],
+      subject: "S",
+      text: "T",
+    });
+
+    const input = sesMock.commandCalls(SendEmailCommand)[0].args[0].input;
+    expect(input.EmailTags).toBeUndefined();
+  });
+
+  it("delegates to sendRawEmail when attachments are present", async () => {
+    sesMock.on(SendEmailCommand).resolves({ MessageId: "raw-msg" });
+
+    const id = await sendEmail({
+      from: "from@x.com",
+      to: ["to@x.com"],
+      subject: "S",
+      text: "T",
+      attachments: [
+        {
+          filename: "a.txt",
+          content: Buffer.from("hello").toString("base64"),
+          contentType: "text/plain",
+        },
+      ],
+    });
+
+    expect(id).toBe("raw-msg");
+    // Single SendEmailCommand call, but with Raw content (delegated branch)
+    const calls = sesMock.commandCalls(SendEmailCommand);
+    expect(calls).toHaveLength(1);
+    const data = calls[0].args[0].input.Content?.Raw?.Data;
+    // node:util's TextEncoder returns a Uint8Array, but cross-realm checks
+    // (jsdom vs node) can break instanceof. Duck-type instead.
+    expect(data).toBeDefined();
+    expect(typeof (data as Uint8Array).byteLength).toBe("number");
+    expect((data as Uint8Array).byteLength).toBeGreaterThan(0);
+    expect(calls[0].args[0].input.Content?.Simple).toBeUndefined();
+  });
+});
+
+describe("sendRawEmail (Raw content)", () => {
+  it("issues v2 SendEmailCommand with FromEmailAddress + Destination.ToAddresses + Content.Raw", async () => {
+    sesMock.on(SendEmailCommand).resolves({ MessageId: "raw-1" });
+
+    const id = await sendRawEmail({
+      from: "from@x.com",
+      to: ["to1@x.com", "to2@x.com"],
+      cc: ["cc1@x.com"],
+      bcc: ["bcc1@x.com"],
+      subject: "Subj",
+      html: "<p>html</p>",
+      text: "text",
+      replyTo: ["reply@x.com"],
+      attachments: [
+        {
+          filename: "a.txt",
+          content: Buffer.from("hi").toString("base64"),
+          contentType: "text/plain",
+        },
+      ],
+    });
+
+    expect(id).toBe("raw-1");
+
+    const calls = sesMock.commandCalls(SendEmailCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0].args[0].input;
+
+    expect(input.FromEmailAddress).toBe("from@x.com");
+    // v2 puts all recipients (to+cc+bcc) into Destination.ToAddresses for raw
+    // because the actual envelope is in the MIME headers; we mirror v1
+    // behavior of flattening recipients.
+    expect(input.Destination?.ToAddresses).toEqual([
+      "to1@x.com",
+      "to2@x.com",
+      "cc1@x.com",
+      "bcc1@x.com",
+    ]);
+    expect(input.ReplyToAddresses).toEqual(["reply@x.com"]);
+
+    // Raw content present, Simple absent
+    expect(input.Content?.Raw?.Data).toBeDefined();
+    expect(input.Content?.Simple).toBeUndefined();
+
+    // v1-style top-level keys must not leak
+    const inputAsRecord = input as Record<string, unknown>;
+    expect(inputAsRecord.Source).toBeUndefined();
+    expect(inputAsRecord.Destinations).toBeUndefined();
+    expect(inputAsRecord.RawMessage).toBeUndefined();
+
+    // Sanity-check the MIME body still contains expected headers
+    const decoded = new TextDecoder().decode(
+      input.Content?.Raw?.Data as Uint8Array
+    );
+    expect(decoded).toContain("From: from@x.com");
+    expect(decoded).toContain("To: to1@x.com, to2@x.com");
+    expect(decoded).toContain("Cc: cc1@x.com");
+    expect(decoded).toContain("Reply-To: reply@x.com");
+    expect(decoded).toContain("Subject: Subj");
+    expect(decoded).toContain("filename=\"a.txt\"");
+  });
+
+  it("omits Cc and Reply-To headers when not supplied", async () => {
+    sesMock.on(SendEmailCommand).resolves({ MessageId: "raw-2" });
+
+    await sendRawEmail({
+      from: "from@x.com",
+      to: ["to@x.com"],
+      subject: "S",
+      text: "T",
+    });
+
+    const input = sesMock.commandCalls(SendEmailCommand)[0].args[0].input;
+    const decoded = new TextDecoder().decode(
+      input.Content?.Raw?.Data as Uint8Array
+    );
+    expect(decoded).not.toContain("Cc:");
+    expect(decoded).not.toContain("Reply-To:");
+  });
+});

--- a/src/lib/ses.ts
+++ b/src/lib/ses.ts
@@ -1,16 +1,15 @@
+import { TextEncoder } from "node:util";
 import {
-  SESClient,
+  SESv2Client,
   SendEmailCommand,
-  SendRawEmailCommand,
-  VerifyDomainIdentityCommand,
-  GetIdentityVerificationAttributesCommand,
-  DeleteIdentityCommand,
+  CreateEmailIdentityCommand,
+  GetEmailIdentityCommand,
+  DeleteEmailIdentityCommand,
   CreateConfigurationSetCommand,
-  VerifyDomainDkimCommand,
-  GetIdentityDkimAttributesCommand,
-} from "@aws-sdk/client-ses";
+  PutEmailIdentityDkimAttributesCommand,
+} from "@aws-sdk/client-sesv2";
 
-const sesClient = new SESClient({
+const sesClient = new SESv2Client({
   region: process.env.AWS_REGION || "us-east-1",
   credentials: {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
@@ -37,9 +36,39 @@ export interface SendEmailOptions {
   tags?: Record<string, string>;
 }
 
+export type SESVerificationStatus =
+  | "Pending"
+  | "Success"
+  | "Failed"
+  | "TemporaryFailure"
+  | "NotStarted";
+
 export interface SESVerificationResult {
   verificationToken: string;
-  status: "Pending" | "Success" | "Failed" | "TemporaryFailure" | "NotStarted";
+  status: SESVerificationStatus;
+}
+
+/**
+ * Map v2 enum (`PENDING|SUCCESS|FAILED|TEMPORARY_FAILURE|NOT_STARTED`) to
+ * v1-compatible PascalCase string preserved in the public API.
+ */
+function mapVerificationStatus(
+  v2Status: string | undefined
+): SESVerificationStatus {
+  switch (v2Status) {
+    case "PENDING":
+      return "Pending";
+    case "SUCCESS":
+      return "Success";
+    case "FAILED":
+      return "Failed";
+    case "TEMPORARY_FAILURE":
+      return "TemporaryFailure";
+    case "NOT_STARTED":
+    case undefined:
+    default:
+      return "NotStarted";
+  }
 }
 
 export async function sendEmail(options: SendEmailOptions): Promise<string> {
@@ -51,34 +80,36 @@ export async function sendEmail(options: SendEmailOptions): Promise<string> {
   }
 
   const command = new SendEmailCommand({
-    Source: from,
+    FromEmailAddress: from,
     Destination: {
       ToAddresses: to,
       CcAddresses: cc,
       BccAddresses: bcc,
     },
-    Message: {
-      Subject: {
-        Data: subject,
-        Charset: "UTF-8",
-      },
-      Body: {
-        Html: html
-          ? {
-              Data: html,
-              Charset: "UTF-8",
-            }
-          : undefined,
-        Text: text
-          ? {
-              Data: text,
-              Charset: "UTF-8",
-            }
-          : undefined,
+    Content: {
+      Simple: {
+        Subject: {
+          Data: subject,
+          Charset: "UTF-8",
+        },
+        Body: {
+          Html: html
+            ? {
+                Data: html,
+                Charset: "UTF-8",
+              }
+            : undefined,
+          Text: text
+            ? {
+                Data: text,
+                Charset: "UTF-8",
+              }
+            : undefined,
+        },
       },
     },
     ReplyToAddresses: replyTo,
-    Tags: tags
+    EmailTags: tags
       ? Object.entries(tags).map(([Name, Value]) => ({ Name, Value }))
       : undefined,
   });
@@ -145,11 +176,16 @@ export async function sendRawEmail(options: SendEmailOptions): Promise<string> {
 
   rawMessage += `--${boundary}--\r\n`;
 
-  const command = new SendRawEmailCommand({
-    Source: from,
-    Destinations: recipients,
-    RawMessage: {
-      Data: new TextEncoder().encode(rawMessage),
+  const command = new SendEmailCommand({
+    FromEmailAddress: from,
+    Destination: {
+      ToAddresses: recipients,
+    },
+    ReplyToAddresses: replyTo,
+    Content: {
+      Raw: {
+        Data: new TextEncoder().encode(rawMessage),
+      },
     },
   });
 
@@ -160,14 +196,30 @@ export async function sendRawEmail(options: SendEmailOptions): Promise<string> {
 export async function verifyDomain(
   domain: string
 ): Promise<SESVerificationResult> {
-  const command = new VerifyDomainIdentityCommand({
-    Domain: domain,
-  });
+  // v2 splits identity creation from verification-token retrieval. Create
+  // the identity (idempotent — swallow AlreadyExistsException) then read
+  // back DkimAttributes.Tokens[0] which doubles as the SES verification
+  // token used in the `_amazonses.<domain>` TXT record.
+  try {
+    await sesClient.send(
+      new CreateEmailIdentityCommand({ EmailIdentity: domain })
+    );
+  } catch (error: unknown) {
+    const awsError = error as { name?: string };
+    if (awsError.name !== "AlreadyExistsException") {
+      throw error;
+    }
+    // identity already present — fall through to GetEmailIdentity
+  }
 
-  const response = await sesClient.send(command);
+  const get = await sesClient.send(
+    new GetEmailIdentityCommand({ EmailIdentity: domain })
+  );
+
+  const verificationToken = get.DkimAttributes?.Tokens?.[0] ?? "";
 
   return {
-    verificationToken: response.VerificationToken!,
+    verificationToken,
     status: "Pending",
   };
 }
@@ -175,42 +227,38 @@ export async function verifyDomain(
 export async function getDomainVerificationStatus(
   domain: string
 ): Promise<string> {
-  const command = new GetIdentityVerificationAttributesCommand({
-    Identities: [domain],
-  });
-
-  const response = await sesClient.send(command);
-  const attributes = response.VerificationAttributes?.[domain];
-
-  return attributes?.VerificationStatus || "NotStarted";
+  const response = await sesClient.send(
+    new GetEmailIdentityCommand({ EmailIdentity: domain })
+  );
+  return mapVerificationStatus(response.VerificationStatus);
 }
 
 export async function enableDomainDkim(domain: string): Promise<string[]> {
-  const command = new VerifyDomainDkimCommand({
-    Domain: domain,
-  });
+  await sesClient.send(
+    new PutEmailIdentityDkimAttributesCommand({
+      EmailIdentity: domain,
+      SigningEnabled: true,
+    })
+  );
 
-  const response = await sesClient.send(command);
-  return response.DkimTokens || [];
+  const get = await sesClient.send(
+    new GetEmailIdentityCommand({ EmailIdentity: domain })
+  );
+
+  return get.DkimAttributes?.Tokens || [];
 }
 
 export async function getDomainDkimTokens(domain: string): Promise<string[]> {
-  const command = new GetIdentityDkimAttributesCommand({
-    Identities: [domain],
-  });
-
-  const response = await sesClient.send(command);
-  const attributes = response.DkimAttributes?.[domain];
-
-  return attributes?.DkimTokens || [];
+  const response = await sesClient.send(
+    new GetEmailIdentityCommand({ EmailIdentity: domain })
+  );
+  return response.DkimAttributes?.Tokens || [];
 }
 
 export async function deleteDomainIdentity(domain: string): Promise<void> {
-  const command = new DeleteIdentityCommand({
-    Identity: domain,
-  });
-
-  await sesClient.send(command);
+  await sesClient.send(
+    new DeleteEmailIdentityCommand({ EmailIdentity: domain })
+  );
 }
 
 export async function createConfigurationSet(domain: string): Promise<string> {
@@ -218,16 +266,18 @@ export async function createConfigurationSet(domain: string): Promise<string> {
 
   try {
     const command = new CreateConfigurationSetCommand({
-      ConfigurationSet: {
-        Name: configSetName,
-      },
+      ConfigurationSetName: configSetName,
     });
 
     await sesClient.send(command);
 
     return configSetName;
   } catch (error: unknown) {
-    const awsError = error as { name?: string; message?: string; $metadata?: { httpStatusCode?: number } };
+    const awsError = error as {
+      name?: string;
+      message?: string;
+      $metadata?: { httpStatusCode?: number };
+    };
     // Handle various ways AWS might indicate the configuration set already exists
     if (
       awsError.name === "AlreadyExistsException" ||


### PR DESCRIPTION
## 요약
- `src/lib/ses.ts` 를 `@aws-sdk/client-ses` (v1) 에서 `@aws-sdk/client-sesv2` (v2) 로 마이그레이션. 모든 public 함수 시그니처를 보존하여 consumer (`domains.ts`, API 라우트) 변경 0건.
- `aws-sdk-client-mock` 으로 32 개 단위 테스트 추가 (라이브 AWS 호출 없음).
- `docs/plan/` 첫 plan 문서 추가.

Closes #1.

## 상세
v2 는 verify 상태 + DKIM 을 단일 `GetEmailIdentity` 호출로 통합한 현재 AWS 권장 SDK 다. 기존 v1 스타일 반환 shape (`{ verificationToken, status: "Pending" }`, PascalCase 상태 enum, DKIM 토큰 배열) 은 각 함수 내부에서 매핑하여 보존한다. `verifyDomain` 은 `AlreadyExistsException` 을 swallow 하고 `GetEmailIdentity` 로 폴스루하여 v1 의 멱등 동작을 유지.

`jest.config.js` 가 이제 `sinon` 을 CJS 빌드로 해석한다 — `next/jest` 가 `aws-sdk-client-mock` 의 sinon dependency 에서 ESM 엔트리를 픽업해 트랜스폼 실패하던 문제 해결.

DNS provider 추상화 (Route53 모듈) 는 의도적으로 본 PR 범위 밖 — 별도 plan.

## 변경 파일
```
docs/plan/
└── 001-ses-v2-migration.md         # 신규 — v1→v2 매핑 표와 TDD 순서 phase 포함 plan
src/lib/
├── ses.ts                          # @aws-sdk/client-sesv2 로 재작성
└── __tests__/
    └── ses.test.ts                 # 신규 — aws-sdk-client-mock 기반 32 단위 테스트
jest.config.js                       # moduleNameMapper: sinon → CJS 빌드
package.json                         # @aws-sdk/client-ses 제거, sesv2 + aws-sdk-client-mock 추가
package-lock.json                    # lock 갱신
```

## 커밋
- [`61ae6af`](https://github.com/Orchemi/my-resend/commit/61ae6af) docs(plan): add 001 SES v2 migration plan
- [`e400129`](https://github.com/Orchemi/my-resend/commit/e400129) feat(ses): migrate AWS SDK from v1 to v2 with unit tests

## 테스트 계획
- [x] `npm run lint` — warning/error 0
- [x] `npm test -- --testPathPatterns='src/lib/__tests__/ses'` — 32 통과
- [x] `npm test -- --testPathPatterns='src/lib'` — 4 suites / 83 tests 통과 (회귀 0)
- [x] `npm run build` — 21 routes, typecheck OK (consumer 변경 0)