### PR TITLE
Route53 DNS provider 추가 + DNS_PROVIDER 추상화

### DIFF
--- a/docs/plan/002-route53-dns-provider.md
+++ b/docs/plan/002-route53-dns-provider.md
@@ -1,0 +1,164 @@
+# 002-route53-dns-provider
+
+## 개요
+
+- **이슈**: [#4](https://github.com/Orchemi/my-resend/issues/4)
+- **브랜치**: `feat/4`
+- **상태**: 진행 중
+- **생성일**: 2026-04-26
+- **선행**: [#2](https://github.com/Orchemi/my-resend/pull/2) (SES SDK v1→v2 마이그레이션) 머지됨
+
+이 문서는 my-resend 의 DNS 자동화 모듈을 **provider-pluggable** 구조로 전환하고, AWS Route53 provider 를 신설하는 작업의 단일 진실(single source of truth) 이다.
+
+## 배경
+
+현재 my-resend 의 DNS 자동 등록은 `src/lib/digitalocean.ts` 한 곳에 직결되어 있다 (`domains.ts`, `app/api/domains/[id]/retry-dns/route.ts` 가 `digitalocean` 모듈을 직접 import).
+
+다음 단계로 자연스러운 확장은:
+
+1. **AWS Route53 provider 추가** — AWS 인프라 (특히 SES + Route53 같은 계정에서 운영) 에 배치하려는 사용자가 DigitalOcean 계정 없이 도메인 인증을 자동화할 수 있어야 한다.
+2. **provider 추상화 도입** — 위 두 provider 를 하나의 인터페이스 뒤로 숨겨 consumer (`domains.ts`, API 라우트) 가 provider 분기를 모르도록 한다. 향후 Cloudflare 등 다른 provider 도 같은 패턴으로 추가 가능.
+3. **backward compat 보존** — 기존 사용자(상위 fork 포함) 가 `DNS_PROVIDER` 를 설정하지 않아도 DigitalOcean 동작이 그대로 유지되어야 한다.
+
+## 목표
+
+- [ ] 의존성 추가: `@aws-sdk/client-route-53`
+- [ ] `src/lib/route53.ts` 신설 — `digitalocean.ts` 가 `domains.ts` 에 노출하는 surface (`setupDomainDNS`, `verifyDomainOwnership`) 를 동일 시그니처로 구현
+- [ ] `src/lib/dns-provider.ts` 신설 — `DNS_PROVIDER` env 분기 (`digitalocean` | `route53`, default `digitalocean`)
+- [ ] `src/lib/domains.ts` 와 `src/app/api/domains/[id]/retry-dns/route.ts` 가 `dns-provider` 를 import 하도록 갱신 (직접 `digitalocean` import 제거)
+- [ ] 단위 테스트:
+  - `route53.test.ts` (`aws-sdk-client-mock` 사용)
+  - `dns-provider.test.ts` (env 분기)
+- [ ] 통합 테스트: `domains.ts.addDomain` 흐름을 두 provider 모두에서 (각각 mock 으로) 검증 — 추상화가 실제로 동작함을 증명
+- [ ] `npm run lint && npm test && npm run build` 모두 통과
+- [ ] PR (1 커밋 rebase / 2+ 커밋 merge)
+
+## 설계
+
+### 접근 방식
+
+1. **dns-provider 가 unified API**. consumer 는 `dns-provider.setupDomainDNS(domain, dnsRecords)` / `dns-provider.verifyDomainOwnership(domain)` 만 호출. 분기 로직은 provider 모듈 내부.
+2. **route53.ts 는 native 로 unified shape 반환**. 즉 `DnsProviderRecord { type, name, value, ttl }` 로 정규화된 배열 반환.
+3. **digitalocean.ts 는 무수정**. 외부 호환성 보존 — 이미 `DODomainRecord` 를 반환하는 모듈이고, 공개 surface 다. `dns-provider.ts` 가 wrapping 시 변환만 추가.
+4. **`DomainSetupResult.digitalOceanRecords` 필드명 → `dnsProviderRecords`** — 내부 타입 리네임. JSON API 응답 필드는 `createdRecords`(retry-dns) / `digitalOceanRecords`(addDomain 미사용 외부) 등으로 별개. 외부 노출 파급 grep 후 결정 — 0건이면 그대로 리네임, 있으면 deprecated 필드 보존.
+5. **TDD**. 각 함수에 대해 mock 으로 입력·반환 매핑을 단위 테스트로 먼저 정의 → 구현. 라이브 AWS 호출 없음.
+6. **env 검증**: `DNS_PROVIDER=route53` 인데 `AWS_HOSTED_ZONE_ID` 미설정 → `verifyDomainOwnership` false, `setupDomainDNS` throw — `DO_API_TOKEN` 부재 시 `digitalocean.ts` 가 하는 것과 같은 패턴.
+
+### 변경 범위
+
+```
+my-resend/
+├── package.json                              # @aws-sdk/client-route-53 추가
+├── package-lock.json                         # 자동 갱신
+├── src/lib/
+│   ├── dns-provider.ts                       # 신규 — 추상화 + env 분기
+│   ├── route53.ts                            # 신규 — Route53 SDK wrapper
+│   ├── domains.ts                            # import 변경 (digitalocean → dns-provider) + 필드명 정리
+│   └── __tests__/
+│       ├── route53.test.ts                   # 신규
+│       ├── dns-provider.test.ts              # 신규
+│       └── domains-dns-integration.test.ts   # 신규 (통합)
+├── src/app/api/domains/[id]/retry-dns/
+│   └── route.ts                              # import 변경
+└── docs/plan/
+    └── 002-route53-dns-provider.md           # 본 문서
+```
+
+**무변경**:
+- `src/lib/digitalocean.ts` (모듈 자체는 유지 — `dns-provider` 가 wrap)
+- `src/lib/ses.ts` (Route53 와 직교)
+- 기타 라우트·컴포넌트
+
+### Route53 매핑
+
+| Operation | Route53 SDK call | 비고 |
+|-----------|------------------|------|
+| Create / upsert DNS records | `ChangeResourceRecordSetsCommand` (`Action: UPSERT`) | 한 번의 setup 호출당 ChangeBatch 1건. 각 `DNSRecord` 가 `ResourceRecordSet` 1개로 매핑. MX 값 (`"10 mail.example.com."`) 은 priority/host 분리 — Route53 는 단일 `Value` 문자열에 그대로 둔다. CNAME 값의 trailing dot 보존 |
+| List existing records | `ListResourceRecordSetsCommand` (paginated) | 멱등성 검사용 — 동일 type+name+value 조합이 이미 있으면 skip |
+| Verify domain ownership | `ListHostedZonesByNameCommand` 또는 `GetHostedZoneCommand` | "owned" = 매칭되는 hosted zone 이 내 계정에 존재. `AWS_HOSTED_ZONE_ID` env 가 있으면 그것을 신뢰하고 `GetHostedZone` 으로 존재만 확인 |
+
+### env 모델
+
+| env | 적용 시점 | 기본값 | 비고 |
+|-----|----------|--------|------|
+| `DNS_PROVIDER` | dns-provider.ts | `digitalocean` | `digitalocean` \| `route53`. 그 외 값은 throw |
+| `DO_API_TOKEN` | digitalocean.ts | — | provider=digitalocean 시 필수 |
+| `AWS_HOSTED_ZONE_ID` | route53.ts | — | provider=route53 시 필수 |
+| `AWS_REGION` | route53.ts (route53 는 글로벌이라 region 무관하지만 SDK 가 요구) | `us-east-1` | SES 와 동일 fallback |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | route53.ts | — | provider=route53 시 필수. SES 와 공유 |
+
+### 의사결정 기록
+
+| 결정 사항 | 선택지 | 결정 | 이유 |
+|-----------|--------|------|------|
+| 추상화 위치 | A) `dns-provider.ts` 단일 모듈 / B) `dns/{digitalocean,route53,index}.ts` 디렉토리 | **A** | provider 2개에 각 ~150 LOC 정도. 파일 분리는 over-engineering. 후속에 3개 이상 늘면 디렉토리화 |
+| `digitalocean.ts` 수정 여부 | A) 그대로 + dns-provider 가 wrap / B) 함수 시그니처 통일하도록 수정 | **A** | upstream 와 충돌 최소화. wrap 의 변환 로직은 dns-provider 안 한 곳 |
+| Route53 ChangeBatch 크기 | A) 레코드별 1 batch / B) 전체 묶어 1 batch | **B** | Route53 가 atomic batch 지원. SES verify TXT + DKIM CNAME 3개 + SPF + DMARC = 보통 6개 — 한 번에 보내는 것이 자연스럽고 빠름 |
+| 멱등성 처리 | A) 항상 UPSERT (무조건 덮어씀) / B) List 먼저 → 차이만 적용 | **B** | DigitalOcean 모듈이 List 기반 멱등성을 갖고 있어 동작 일관성 유지. UPSERT 만 쓰면 사용자가 수동 편집한 레코드를 덮어쓸 위험 |
+| 필드명 `digitalOceanRecords` | A) 유지 / B) `dnsProviderRecords` 로 rename | **B** | 추상화의 의미가 사라지지 않도록. 외부 JSON 노출 grep 결과 따라 호환 처리 |
+| `DNS_PROVIDER` 미설정 동작 | A) throw / B) `digitalocean` 기본값 | **B** | upstream 에서 fork 한 사용자의 기존 환경변수가 그대로 동작해야 함 (backward compat) |
+| `DNS_PROVIDER=unknown` 처리 | A) silent fallback / B) throw | **B** | 오타로 인한 silent 동작 변경 금지 — 명시적 에러로 fail-fast |
+| 통합 테스트 수준 | A) unit 만 / B) `domains.ts.addDomain` 까지 / C) HTTP 레벨 | **B** | DB 의존이 있어 HTTP 레벨은 별도 인프라 필요 (Phase 7 e2e). `addDomain` 은 dns-provider 위에서 동작하므로 추상화 검증 1차 충분 |
+
+## 작업 단계
+
+### Phase 1: 의존성 + 추상화 골격
+
+- [ ] `npm install @aws-sdk/client-route-53`
+- [ ] `src/lib/dns-provider.ts` 골격 작성 — type, env 분기 (디스패처는 빈 함수로)
+- [ ] `__tests__/dns-provider.test.ts` 작성 (env=digitalocean / env=route53 / env=unknown / env undefined → digitalocean)
+
+### Phase 2: route53.ts TDD
+
+- [ ] `__tests__/route53.test.ts` 셋업 (`aws-sdk-client-mock` + `Route53Client`)
+- [ ] `verifyDomainOwnership` 테스트 + 구현 — `AWS_HOSTED_ZONE_ID` 있으면 `GetHostedZone` 으로 존재 확인. 없으면 false
+- [ ] `setupDomainDNS` 테스트 + 구현 — `ListResourceRecordSets` → 차이 계산 → `ChangeResourceRecordSets` UPSERT
+  - MX 값 분리·CNAME trailing dot 보존
+  - 이미 동일 record 존재 → skip + 로그
+  - 빈 ChangeBatch → no-op (SDK 호출 안 함)
+- [ ] returns: `DnsProviderRecord[]` (생성·갱신된 항목만)
+
+### Phase 3: dns-provider.ts 디스패처 완성
+
+- [ ] `setupDomainDNS` / `verifyDomainOwnership` 가 env 에 따라 모듈 위임
+- [ ] DigitalOcean 경로: `digitalocean.ts.setupDomainDNS` 호출 후 `DODomainRecord[]` → `DnsProviderRecord[]` 변환
+- [ ] Route53 경로: `route53.ts` 결과 그대로 반환
+
+### Phase 4: consumer 갱신
+
+- [ ] `src/lib/domains.ts`: `from "./digitalocean"` → `from "./dns-provider"`. `digitalOceanRecords` 필드 → `dnsProviderRecords` (외부 JSON 노출 grep 후 결정)
+- [ ] `src/app/api/domains/[id]/retry-dns/route.ts`: 동일 import 변경. 응답 메시지 "DigitalOcean" 하드코딩 제거 → 일반 표현 ("DNS provider")
+- [ ] `convertDORecordToDNSRecord` 헬퍼 제거 (dns-provider 가 이미 변환된 shape 반환)
+
+### Phase 5: 통합 테스트
+
+- [ ] `__tests__/domains-dns-integration.test.ts`:
+  - `DNS_PROVIDER=digitalocean` + axios mock — `addDomain` 흐름이 `digitalocean.ts` 만 호출하고 Route53 SDK 는 호출 안 함
+  - `DNS_PROVIDER=route53` + Route53 mock — `addDomain` 흐름이 `Route53Client` 만 호출하고 axios 는 호출 안 함
+
+### Phase 6: 검증
+
+- [ ] `npm run lint` 통과
+- [ ] `npm test` 전체 통과 (기존 ses + waitlist + notifications + pricing-calculator + 신규 3 suite)
+- [ ] `npm run build` 통과
+
+### Phase 7: 커밋 + PR
+
+- [ ] 영어 conventional 커밋
+- [ ] `gh pr create --base develop`
+- [ ] PR 머지 후 본 문서 진행 로그 갱신
+
+## 진행 로그
+
+| 날짜 | 내용 | 비고 |
+|------|------|------|
+| 2026-04-26 | 이슈 #4, `feat/4` 브랜치, 본 plan 작성 | PR #2 (SES v2) 직후 후속 트랙 |
+
+## 참고
+
+- AWS Route53 SDK v3 (JavaScript): <https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/route-53/>
+- Route53 ResourceRecordSet 모델: <https://docs.aws.amazon.com/Route53/latest/APIReference/API_ResourceRecordSet.html>
+- Route53 ChangeResourceRecordSets: <https://docs.aws.amazon.com/Route53/latest/APIReference/API_ChangeResourceRecordSets.html>
+- aws-sdk-client-mock: <https://github.com/m-radzikowski/aws-sdk-client-mock>
+- 선행 PR: <https://github.com/Orchemi/my-resend/pull/2>
+- 직전 plan: `docs/plan/001-ses-v2-migration.md`

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,11 @@ const createJestConfig = nextJest({
 
 // Add any custom config to be passed to Jest
 const customJestConfig = {
+  // Run before each test file's module graph loads. Seeds env vars that
+  // source modules (e.g. src/lib/digitalocean.ts) capture at
+  // module-load time, so jest.mock + import order doesn't have to fight
+  // process.env timing.
+  setupFiles: ['<rootDir>/jest.setup.env.js'],
   setupFilesAfterEnv: [],
   testEnvironment: 'jsdom',
   collectCoverageFrom: [

--- a/jest.setup.env.js
+++ b/jest.setup.env.js
@@ -1,0 +1,5 @@
+// Seed env vars that some src/lib/*.ts modules read at module-load time
+// (before any test code can run). Test cases may still override these
+// via process.env mutations + module re-import patterns where needed.
+process.env.DO_API_TOKEN = process.env.DO_API_TOKEN || "test-do-token";
+process.env.AWS_REGION = process.env.AWS_REGION || "us-east-1";

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-iam": "^3.899.0",
+        "@aws-sdk/client-route-53": "^3.1037.0",
         "@aws-sdk/client-sesv2": "^3.1037.0",
         "@types/pg": "^8.15.5",
         "axios": "^1.7.9",
@@ -720,6 +721,58 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-route-53": {
+      "version": "3.1037.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-route-53/-/client-route-53-3.1037.0.tgz",
+      "integrity": "sha512-xOqyUpzkKopysLqRJDxZDC0ndEmbdyi4k15Om7U42Xo6Lb+tEAmvIRmgq34BJVfSeDVtjQqkdvyVvhSYlUPqgA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/credential-provider-node": "^3.972.36",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-sdk-route53": "^3.972.12",
+        "@aws-sdk/middleware-user-agent": "^3.972.35",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.21",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.5",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.16",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-sesv2": {
       "version": "3.1037.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.1037.0.tgz",
@@ -1006,6 +1059,20 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-route53": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-route53/-/middleware-sdk-route53-3.972.12.tgz",
+      "integrity": "sha512-nj08j4q/Rp8zb3SqwxE+dex22NdXoSKJAh445x0SLGAI23lYfDTujFDG1JRYLRc1uR2/FPPr76L/ki/VE4J9ig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
@@ -3582,19 +3649,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@smithy/abort-controller": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.0.tgz",
-      "integrity": "sha512-PLUYa+SUKOEZtXFURBu/CNxlsxfaFGxSBPcStL13KpVeVWIfdezWyDqkz7iDLmwnxojXD0s5KzuB5HGHvt4Aeg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.6.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@smithy/config-resolver": {
       "version": "4.4.17",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
@@ -4152,13 +4206,12 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.0.tgz",
-      "integrity": "sha512-0Z+nxUU4/4T+SL8BCNN4ztKdQjToNvUYmkF1kXO5T7Yz3Gafzh0HeIG6mrkN8Fz3gn9hSyxuAT+6h4vM+iQSBQ==",
+      "version": "4.2.16",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.16.tgz",
+      "integrity": "sha512-GtclrKoZ3Lt7jPQ7aTIYKfjY92OgceScftVnkTsG8e1KV8rkvZgN+ny6YSRhd9hxB8rZtwVbmln7NTvE5O3GmQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.0",
-        "@smithy/types": "^4.6.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-iam": "^3.899.0",
+    "@aws-sdk/client-route-53": "^3.1037.0",
     "@aws-sdk/client-sesv2": "^3.1037.0",
     "@types/pg": "^8.15.5",
     "axios": "^1.7.9",

--- a/src/app/api/domains/[id]/retry-dns/route.ts
+++ b/src/app/api/domains/[id]/retry-dns/route.ts
@@ -1,11 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { verifyJWT } from "@/lib/auth";
 import { getDomainById } from "@/lib/domains";
-import {
-  setupDomainDNS,
-  verifyDomainOwnership,
-  type DODomainRecord,
-} from "@/lib/digitalocean";
+import { setupDomainDNS, verifyDomainOwnership } from "@/lib/dns-provider";
 import { generateDNSRecords, getDomainDkimTokens } from "@/lib/ses";
 
 function cors(response: NextResponse) {
@@ -19,21 +15,6 @@ function cors(response: NextResponse) {
     "Content-Type, Authorization"
   );
   return response;
-}
-
-// Helper function to convert DODomainRecord to DNSRecord
-function convertDORecordToDNSRecord(doRecord: DODomainRecord): {
-  type: string;
-  name: string;
-  value: string;
-  ttl: number;
-} {
-  return {
-    type: doRecord.type,
-    name: doRecord.name,
-    value: doRecord.data,
-    ttl: doRecord.ttl,
-  };
 }
 
 export async function POST(
@@ -96,28 +77,31 @@ export async function POST(
         dkimTokens
       );
 
-      // Check if domain exists in Digital Ocean
-      console.log(`Checking if ${domainName} exists in DigitalOcean...`);
-      const isDomainInDO = await verifyDomainOwnership(domainName);
-      if (!isDomainInDO) {
+      // Check if domain is managed by the configured DNS provider
+      console.log(
+        `Checking if ${domainName} is managed by configured DNS provider...`
+      );
+      const isDomainOwned = await verifyDomainOwnership(domainName);
+      if (!isDomainOwned) {
         return cors(
           NextResponse.json(
             {
               success: false,
-              error: `Domain ${domainName} not found in your DigitalOcean account. Please add it first.`,
+              error: `Domain ${domainName} is not managed by the configured DNS provider. Please add it first.`,
             },
             { status: 400 }
           )
         );
       }
 
-      // Setup DNS in Digital Ocean
-      console.log(`Setting up DigitalOcean DNS for ${domainName}...`);
-      const doRecords = await setupDomainDNS(domainName, dnsRecords);
-      const digitalOceanRecords = doRecords.map(convertDORecordToDNSRecord);
+      // Setup DNS via the configured DNS provider
+      console.log(
+        `Setting up DNS via configured DNS provider for ${domainName}...`
+      );
+      const createdRecords = await setupDomainDNS(domainName, dnsRecords);
 
       console.log(
-        `Successfully created ${doRecords.length} DNS records for ${domainName}`
+        `Successfully created ${createdRecords.length} DNS records for ${domainName}`
       );
 
       return cors(
@@ -125,11 +109,11 @@ export async function POST(
           success: true,
           data: {
             domain: domainName,
-            createdRecords: digitalOceanRecords,
+            createdRecords,
             setupInstructions:
-              "DNS records have been successfully created/updated in DigitalOcean.",
+              "DNS records have been successfully created/updated via the configured DNS provider.",
           },
-          message: `DNS setup completed successfully for ${domainName}. Created ${doRecords.length} records.`,
+          message: `DNS setup completed successfully for ${domainName}. Created ${createdRecords.length} records.`,
         })
       );
     } catch (error: unknown) {
@@ -141,9 +125,9 @@ export async function POST(
         NextResponse.json(
           {
             success: false,
-            error: `Failed to setup DigitalOcean DNS: ${errorMessage}`,
+            error: `Failed to setup DNS via configured DNS provider: ${errorMessage}`,
             suggestion:
-              "Please check your DigitalOcean API token permissions and try again.",
+              "Please check your DNS provider credentials and permissions, then try again.",
           },
           { status: 500 }
         )

--- a/src/lib/__tests__/dns-provider.test.ts
+++ b/src/lib/__tests__/dns-provider.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Unit tests for src/lib/dns-provider.ts (DNS provider env dispatcher).
+ *
+ * Strategy:
+ *   - getDnsProviderName: pure env-branching helper, tested in isolation.
+ *   - setupDomainDNS / verifyDomainOwnership: the dispatcher delegates to
+ *     either digitalocean.ts or route53.ts; both modules are jest.mock'd
+ *     here so we assert delegation behavior + shape conversion without
+ *     touching axios/AWS SDK.
+ */
+jest.mock("../digitalocean", () => ({
+  __esModule: true,
+  setupDomainDNS: jest.fn(),
+  verifyDomainOwnership: jest.fn(),
+}));
+jest.mock("../route53", () => ({
+  __esModule: true,
+  setupDomainDNS: jest.fn(),
+  verifyDomainOwnership: jest.fn(),
+}));
+
+import {
+  getDnsProviderName,
+  setupDomainDNS,
+  verifyDomainOwnership,
+} from "../dns-provider";
+import * as digitalocean from "../digitalocean";
+import * as route53 from "../route53";
+
+const doSetupMock = digitalocean.setupDomainDNS as jest.MockedFunction<
+  typeof digitalocean.setupDomainDNS
+>;
+const doVerifyMock = digitalocean.verifyDomainOwnership as jest.MockedFunction<
+  typeof digitalocean.verifyDomainOwnership
+>;
+const r53SetupMock = route53.setupDomainDNS as jest.MockedFunction<
+  typeof route53.setupDomainDNS
+>;
+const r53VerifyMock = route53.verifyDomainOwnership as jest.MockedFunction<
+  typeof route53.verifyDomainOwnership
+>;
+
+describe("getDnsProviderName", () => {
+  const ORIGINAL_ENV = process.env.DNS_PROVIDER;
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.DNS_PROVIDER;
+    } else {
+      process.env.DNS_PROVIDER = ORIGINAL_ENV;
+    }
+  });
+
+  it("returns 'digitalocean' when DNS_PROVIDER is unset (backward compat)", () => {
+    delete process.env.DNS_PROVIDER;
+    expect(getDnsProviderName()).toBe("digitalocean");
+  });
+
+  it("returns 'digitalocean' when DNS_PROVIDER='digitalocean'", () => {
+    process.env.DNS_PROVIDER = "digitalocean";
+    expect(getDnsProviderName()).toBe("digitalocean");
+  });
+
+  it("returns 'route53' when DNS_PROVIDER='route53'", () => {
+    process.env.DNS_PROVIDER = "route53";
+    expect(getDnsProviderName()).toBe("route53");
+  });
+
+  it("throws fail-fast on an unknown DNS_PROVIDER value", () => {
+    process.env.DNS_PROVIDER = "cloudflare";
+    expect(() => getDnsProviderName()).toThrow(/DNS_PROVIDER/);
+  });
+
+  it("is case-insensitive (accepts 'ROUTE53')", () => {
+    process.env.DNS_PROVIDER = "ROUTE53";
+    expect(getDnsProviderName()).toBe("route53");
+  });
+
+  it("treats empty string as unset and falls back to default", () => {
+    process.env.DNS_PROVIDER = "";
+    expect(getDnsProviderName()).toBe("digitalocean");
+  });
+});
+
+describe("setupDomainDNS dispatch", () => {
+  const ORIGINAL_ENV = process.env.DNS_PROVIDER;
+
+  beforeEach(() => {
+    doSetupMock.mockReset();
+    r53SetupMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.DNS_PROVIDER;
+    } else {
+      process.env.DNS_PROVIDER = ORIGINAL_ENV;
+    }
+  });
+
+  it("delegates to digitalocean and converts DODomainRecord[] to DnsProviderRecord[]", async () => {
+    process.env.DNS_PROVIDER = "digitalocean";
+    doSetupMock.mockResolvedValue([
+      {
+        id: 1,
+        type: "TXT",
+        name: "_amazonses",
+        data: "verification-token",
+        ttl: 300,
+      },
+      {
+        id: 2,
+        type: "MX",
+        name: "@",
+        data: "inbound-smtp.us-east-1.amazonaws.com.",
+        priority: 10,
+        ttl: 300,
+      },
+    ]);
+
+    const records = [
+      {
+        type: "TXT",
+        name: "_amazonses.example.com",
+        value: "verification-token",
+        ttl: 300,
+      },
+    ];
+    const result = await setupDomainDNS("example.com", records);
+
+    expect(doSetupMock).toHaveBeenCalledTimes(1);
+    expect(doSetupMock).toHaveBeenCalledWith("example.com", records);
+    expect(r53SetupMock).not.toHaveBeenCalled();
+
+    expect(result).toEqual([
+      { type: "TXT", name: "_amazonses", value: "verification-token", ttl: 300 },
+      {
+        type: "MX",
+        name: "@",
+        // DigitalOcean splits MX into priority + host fields; the
+        // unified shape recombines them into the standard "PRIO HOST"
+        // form that other providers (and operators) expect.
+        value: "10 inbound-smtp.us-east-1.amazonaws.com.",
+        ttl: 300,
+      },
+    ]);
+  });
+
+  it("delegates to route53 and returns its result unchanged (already unified shape)", async () => {
+    process.env.DNS_PROVIDER = "route53";
+    const route53Result = [
+      {
+        type: "TXT",
+        name: "_amazonses.example.com",
+        value: "verification-token",
+        ttl: 300,
+      },
+    ];
+    r53SetupMock.mockResolvedValue(route53Result);
+
+    const records = [
+      {
+        type: "TXT",
+        name: "_amazonses.example.com",
+        value: "verification-token",
+        ttl: 300,
+      },
+    ];
+    const result = await setupDomainDNS("example.com", records);
+
+    expect(r53SetupMock).toHaveBeenCalledTimes(1);
+    expect(r53SetupMock).toHaveBeenCalledWith("example.com", records);
+    expect(doSetupMock).not.toHaveBeenCalled();
+    expect(result).toBe(route53Result);
+  });
+});
+
+describe("verifyDomainOwnership dispatch", () => {
+  const ORIGINAL_ENV = process.env.DNS_PROVIDER;
+
+  beforeEach(() => {
+    doVerifyMock.mockReset();
+    r53VerifyMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.DNS_PROVIDER;
+    } else {
+      process.env.DNS_PROVIDER = ORIGINAL_ENV;
+    }
+  });
+
+  it("delegates to digitalocean when DNS_PROVIDER='digitalocean'", async () => {
+    process.env.DNS_PROVIDER = "digitalocean";
+    doVerifyMock.mockResolvedValue(true);
+
+    const result = await verifyDomainOwnership("example.com");
+
+    expect(result).toBe(true);
+    expect(doVerifyMock).toHaveBeenCalledWith("example.com");
+    expect(r53VerifyMock).not.toHaveBeenCalled();
+  });
+
+  it("delegates to route53 when DNS_PROVIDER='route53'", async () => {
+    process.env.DNS_PROVIDER = "route53";
+    r53VerifyMock.mockResolvedValue(true);
+
+    const result = await verifyDomainOwnership("example.com");
+
+    expect(result).toBe(true);
+    expect(r53VerifyMock).toHaveBeenCalledWith("example.com");
+    expect(doVerifyMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/domains-dns-integration.test.ts
+++ b/src/lib/__tests__/domains-dns-integration.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Integration tests for the DNS provider abstraction.
+ *
+ * These verify that `addDomain` (`src/lib/domains.ts`) — the highest
+ * caller of the abstraction — actually exercises the correct underlying
+ * provider SDK based on the `DNS_PROVIDER` env var, and never touches
+ * the other one. This is the proof that the abstraction is wired up
+ * end-to-end through dns-provider.ts.
+ *
+ * Mocking strategy:
+ *   - `database` (Postgres) and `ses` (AWS SES SDK calls) are stubbed at
+ *     the module level so we don't need a live DB or AWS credentials.
+ *   - For the digitalocean case, `axios` is mocked at the module level
+ *     (digitalocean.ts uses `axios.create()`) — we then assert that
+ *     axios was used and the Route53 SDK was NOT.
+ *   - For the route53 case, `aws-sdk-client-mock` intercepts
+ *     `Route53Client.send()` — we then assert that Route53 was used and
+ *     axios was NOT.
+ */
+
+// IMPORTANT: jest.mock calls must be declared before any import that
+// transitively pulls in the mocked modules.
+jest.mock("../database", () => ({
+  __esModule: true,
+  query: jest.fn(),
+}));
+jest.mock("../ses", () => ({
+  __esModule: true,
+  verifyDomain: jest.fn(),
+  getDomainVerificationStatus: jest.fn(),
+  createConfigurationSet: jest.fn(),
+  generateDNSRecords: jest.fn(),
+  enableDomainDkim: jest.fn(),
+  getDomainDkimTokens: jest.fn(),
+}));
+jest.mock("axios", () => {
+  const mockInstance = {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  };
+  // Stash the instance on globalThis so the test body can grab the
+  // exact object that digitalocean.ts received from `axios.create()`.
+  (globalThis as unknown as { __axiosMockInstance: typeof mockInstance }).__axiosMockInstance =
+    mockInstance;
+  const create = jest.fn(() => mockInstance);
+  return {
+    __esModule: true,
+    default: { create },
+    create,
+  };
+});
+
+import { mockClient } from "aws-sdk-client-mock";
+import {
+  Route53Client,
+  GetHostedZoneCommand,
+  ListResourceRecordSetsCommand,
+  ChangeResourceRecordSetsCommand,
+} from "@aws-sdk/client-route-53";
+
+import { addDomain } from "../domains";
+import * as database from "../database";
+import * as ses from "../ses";
+
+const route53Mock = mockClient(Route53Client);
+
+const queryMock = database.query as jest.MockedFunction<typeof database.query>;
+const verifyDomainMock = ses.verifyDomain as jest.MockedFunction<
+  typeof ses.verifyDomain
+>;
+const enableDkimMock = ses.enableDomainDkim as jest.MockedFunction<
+  typeof ses.enableDomainDkim
+>;
+const createConfigSetMock = ses.createConfigurationSet as jest.MockedFunction<
+  typeof ses.createConfigurationSet
+>;
+const generateDnsRecordsMock = ses.generateDNSRecords as jest.MockedFunction<
+  typeof ses.generateDNSRecords
+>;
+
+// The same axios instance digitalocean.ts received at module-load
+// time, stashed on globalThis by the jest.mock factory above.
+const axiosMockInstance = (
+  globalThis as unknown as {
+    __axiosMockInstance: { get: jest.Mock; post: jest.Mock };
+  }
+).__axiosMockInstance;
+const axiosGetMock = axiosMockInstance.get;
+const axiosPostMock = axiosMockInstance.post;
+
+const ORIGINAL_DNS_PROVIDER = process.env.DNS_PROVIDER;
+const ORIGINAL_AWS_HOSTED_ZONE_ID = process.env.AWS_HOSTED_ZONE_ID;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  route53Mock.reset();
+
+  // Default SES mocks: produce a verification token + 1 DKIM token + a
+  // configuration set + the canonical 4 base DNS records.
+  verifyDomainMock.mockResolvedValue({
+    verificationToken: "verification-token",
+    status: "Pending",
+  });
+  enableDkimMock.mockResolvedValue(["tok1"]);
+  createConfigSetMock.mockResolvedValue("my-resend-example-com");
+  generateDnsRecordsMock.mockReturnValue([
+    {
+      type: "TXT",
+      name: "_amazonses.example.com",
+      value: "verification-token",
+      ttl: 300,
+    },
+    {
+      type: "MX",
+      name: "example.com",
+      value: "10 inbound-smtp.us-east-1.amazonaws.com.",
+      ttl: 300,
+    },
+    {
+      type: "TXT",
+      name: "example.com",
+      value: "v=spf1 include:amazonses.com ~all",
+      ttl: 300,
+    },
+    {
+      type: "TXT",
+      name: "_dmarc.example.com",
+      value: "v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com",
+      ttl: 300,
+    },
+    {
+      type: "CNAME",
+      name: "tok1._domainkey.example.com",
+      value: "tok1.dkim.amazonses.com.",
+      ttl: 300,
+    },
+  ]);
+
+  // Default DB mocks: domain does NOT exist yet (so addDomain takes the
+  // create path), and INSERT returns one row.
+  queryMock.mockImplementation(async (text: string) => {
+    if (text.startsWith("SELECT * FROM domains WHERE domain")) {
+      return {
+        rows: [],
+        rowCount: 0,
+        command: "SELECT",
+        oid: 0,
+        fields: [],
+      } as unknown as Awaited<ReturnType<typeof database.query>>;
+    }
+    if (text.startsWith("INSERT INTO domains")) {
+      return {
+        rows: [
+          {
+            id: "domain-uuid-1",
+            user_id: "user-1",
+            domain: "example.com",
+            status: "pending",
+            ses_configuration_set: "my-resend-example-com",
+            dns_records: "[]",
+            verification_token: "verification-token",
+          },
+        ],
+        rowCount: 1,
+        command: "INSERT",
+        oid: 0,
+        fields: [],
+      } as unknown as Awaited<ReturnType<typeof database.query>>;
+    }
+    return {
+      rows: [],
+      rowCount: 0,
+      command: "",
+      oid: 0,
+      fields: [],
+    } as unknown as Awaited<ReturnType<typeof database.query>>;
+  });
+});
+
+afterEach(() => {
+  if (ORIGINAL_DNS_PROVIDER === undefined) {
+    delete process.env.DNS_PROVIDER;
+  } else {
+    process.env.DNS_PROVIDER = ORIGINAL_DNS_PROVIDER;
+  }
+  if (ORIGINAL_AWS_HOSTED_ZONE_ID === undefined) {
+    delete process.env.AWS_HOSTED_ZONE_ID;
+  } else {
+    process.env.AWS_HOSTED_ZONE_ID = ORIGINAL_AWS_HOSTED_ZONE_ID;
+  }
+});
+
+describe("addDomain with DNS_PROVIDER=digitalocean", () => {
+  beforeEach(() => {
+    process.env.DNS_PROVIDER = "digitalocean";
+    // Provide a token so digitalocean.ts skips the "not configured"
+    // early returns. The actual axios calls are mocked below.
+    process.env.DO_API_TOKEN = "test-do-token";
+
+    // verifyDomainOwnership -> getDomains -> GET /domains
+    // setupDomainDNS -> getDomains + getDomainRecords + createDNSRecord(s)
+    axiosGetMock.mockImplementation(async (url: string) => {
+      if (url === "/domains") {
+        return { data: { domains: [{ name: "example.com", zone_file: "" }] } };
+      }
+      if (url.startsWith("/domains/example.com/records")) {
+        return { data: { domain_records: [] } };
+      }
+      return { data: {} };
+    });
+    axiosPostMock.mockImplementation(async () => {
+      // Returns a fake DODomainRecord shape; the dns-provider conversion
+      // accepts any consistent shape with type/name/data/ttl.
+      return {
+        data: {
+          domain_record: {
+            id: 1,
+            type: "TXT",
+            name: "@",
+            data: "verification-token",
+            ttl: 300,
+          },
+        },
+      };
+    });
+  });
+
+  it("calls axios (digitalocean) and never touches the Route53 SDK", async () => {
+    const result = await addDomain("user-1", "example.com");
+
+    // DigitalOcean side: axios was used.
+    expect(axiosGetMock).toHaveBeenCalled();
+    // Route53 side: nothing was sent.
+    expect(route53Mock.commandCalls(GetHostedZoneCommand)).toHaveLength(0);
+    expect(route53Mock.commandCalls(ListResourceRecordSetsCommand)).toHaveLength(
+      0
+    );
+    expect(
+      route53Mock.commandCalls(ChangeResourceRecordSetsCommand)
+    ).toHaveLength(0);
+
+    // The result still carries the unified-shape records under the
+    // renamed field.
+    expect(result.dnsProviderRecords).toBeDefined();
+    expect(Array.isArray(result.dnsProviderRecords)).toBe(true);
+  });
+});
+
+describe("addDomain with DNS_PROVIDER=route53", () => {
+  beforeEach(() => {
+    process.env.DNS_PROVIDER = "route53";
+    process.env.AWS_HOSTED_ZONE_ID = "Z123EXAMPLE";
+
+    route53Mock.on(GetHostedZoneCommand).resolves({
+      HostedZone: {
+        Id: "/hostedzone/Z123EXAMPLE",
+        Name: "example.com.",
+        CallerReference: "ref",
+      },
+    });
+    route53Mock.on(ListResourceRecordSetsCommand).resolves({
+      ResourceRecordSets: [],
+    });
+    route53Mock.on(ChangeResourceRecordSetsCommand).resolves({
+      ChangeInfo: {
+        Id: "/change/C1",
+        Status: "PENDING",
+        SubmittedAt: new Date(),
+      },
+    });
+  });
+
+  it("calls Route53Client and never touches axios (digitalocean)", async () => {
+    const result = await addDomain("user-1", "example.com");
+
+    // Route53 side: at least one Get + one Change must have happened.
+    expect(
+      route53Mock.commandCalls(GetHostedZoneCommand).length
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      route53Mock.commandCalls(ChangeResourceRecordSetsCommand).length
+    ).toBeGreaterThanOrEqual(1);
+
+    // DigitalOcean side: no axios calls at all.
+    expect(axiosGetMock).not.toHaveBeenCalled();
+    expect(axiosPostMock).not.toHaveBeenCalled();
+
+    // Records returned in the unified shape under the renamed field.
+    expect(result.dnsProviderRecords).toBeDefined();
+    expect(Array.isArray(result.dnsProviderRecords)).toBe(true);
+  });
+});

--- a/src/lib/__tests__/route53.test.ts
+++ b/src/lib/__tests__/route53.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Unit tests for src/lib/route53.ts (Route53 SDK wrapper).
+ *
+ * Strategy: aws-sdk-client-mock intercepts Route53Client.send() calls so
+ * no live AWS request is ever made. Tests verify command input mapping
+ * and response unwrapping into the unified DnsProviderRecord shape.
+ */
+import { mockClient } from "aws-sdk-client-mock";
+import {
+  Route53Client,
+  GetHostedZoneCommand,
+  ListResourceRecordSetsCommand,
+  ChangeResourceRecordSetsCommand,
+} from "@aws-sdk/client-route-53";
+
+import { setupDomainDNS, verifyDomainOwnership } from "../route53";
+import type { DnsProviderRecord } from "../dns-provider";
+
+const route53Mock = mockClient(Route53Client);
+
+const ORIGINAL_HOSTED_ZONE_ID = process.env.AWS_HOSTED_ZONE_ID;
+
+beforeEach(() => {
+  route53Mock.reset();
+});
+
+afterEach(() => {
+  if (ORIGINAL_HOSTED_ZONE_ID === undefined) {
+    delete process.env.AWS_HOSTED_ZONE_ID;
+  } else {
+    process.env.AWS_HOSTED_ZONE_ID = ORIGINAL_HOSTED_ZONE_ID;
+  }
+});
+
+describe("verifyDomainOwnership", () => {
+  it("returns false (and never calls SDK) when AWS_HOSTED_ZONE_ID is unset", async () => {
+    delete process.env.AWS_HOSTED_ZONE_ID;
+
+    const result = await verifyDomainOwnership("example.com");
+
+    expect(result).toBe(false);
+    expect(route53Mock.commandCalls(GetHostedZoneCommand)).toHaveLength(0);
+  });
+
+  it("returns true when GetHostedZone resolves with a HostedZone", async () => {
+    process.env.AWS_HOSTED_ZONE_ID = "Z123EXAMPLE";
+    route53Mock.on(GetHostedZoneCommand).resolves({
+      HostedZone: {
+        Id: "/hostedzone/Z123EXAMPLE",
+        Name: "example.com.",
+        CallerReference: "ref",
+      },
+    });
+
+    const result = await verifyDomainOwnership("example.com");
+
+    expect(result).toBe(true);
+    const calls = route53Mock.commandCalls(GetHostedZoneCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args[0].input).toEqual({ Id: "Z123EXAMPLE" });
+  });
+
+  it("returns false when Route53 throws NoSuchHostedZone", async () => {
+    process.env.AWS_HOSTED_ZONE_ID = "Z123EXAMPLE";
+    const err = Object.assign(new Error("not found"), {
+      name: "NoSuchHostedZone",
+    });
+    route53Mock.on(GetHostedZoneCommand).rejects(err);
+
+    const result = await verifyDomainOwnership("example.com");
+
+    expect(result).toBe(false);
+  });
+
+  it("rethrows unexpected errors (not NoSuchHostedZone)", async () => {
+    process.env.AWS_HOSTED_ZONE_ID = "Z123EXAMPLE";
+    route53Mock
+      .on(GetHostedZoneCommand)
+      .rejects(new Error("permission denied"));
+
+    await expect(verifyDomainOwnership("example.com")).rejects.toThrow(
+      "permission denied"
+    );
+  });
+});
+
+describe("setupDomainDNS", () => {
+  beforeEach(() => {
+    process.env.AWS_HOSTED_ZONE_ID = "Z123EXAMPLE";
+  });
+
+  it("returns [] and issues no SDK calls for an empty record list", async () => {
+    const result = await setupDomainDNS("example.com", []);
+
+    expect(result).toEqual([]);
+    expect(route53Mock.commandCalls(ListResourceRecordSetsCommand)).toHaveLength(
+      0
+    );
+    expect(
+      route53Mock.commandCalls(ChangeResourceRecordSetsCommand)
+    ).toHaveLength(0);
+  });
+
+  it("throws when AWS_HOSTED_ZONE_ID is unset", async () => {
+    delete process.env.AWS_HOSTED_ZONE_ID;
+
+    await expect(
+      setupDomainDNS("example.com", [
+        { type: "TXT", name: "example.com", value: "v=spf1 ~all", ttl: 300 },
+      ])
+    ).rejects.toThrow(/AWS_HOSTED_ZONE_ID/);
+  });
+
+  it("issues a single UPSERT ChangeBatch with all new records", async () => {
+    route53Mock.on(ListResourceRecordSetsCommand).resolves({
+      ResourceRecordSets: [],
+    });
+    route53Mock.on(ChangeResourceRecordSetsCommand).resolves({
+      ChangeInfo: {
+        Id: "/change/C123",
+        Status: "PENDING",
+        SubmittedAt: new Date(),
+      },
+    });
+
+    const records: DnsProviderRecord[] = [
+      {
+        type: "TXT",
+        name: "_amazonses.example.com",
+        value: "verification-token",
+        ttl: 300,
+      },
+      {
+        type: "MX",
+        name: "example.com",
+        value: "10 inbound-smtp.us-east-1.amazonaws.com.",
+        ttl: 300,
+      },
+      {
+        type: "CNAME",
+        name: "tok1._domainkey.example.com",
+        value: "tok1.dkim.amazonses.com.",
+        ttl: 300,
+      },
+    ];
+
+    const result = await setupDomainDNS("example.com", records);
+
+    expect(result).toEqual(records);
+
+    const listCalls = route53Mock.commandCalls(ListResourceRecordSetsCommand);
+    expect(listCalls).toHaveLength(1);
+    expect(listCalls[0].args[0].input).toMatchObject({
+      HostedZoneId: "Z123EXAMPLE",
+    });
+
+    const changeCalls = route53Mock.commandCalls(
+      ChangeResourceRecordSetsCommand
+    );
+    expect(changeCalls).toHaveLength(1);
+    const changeInput = changeCalls[0].args[0].input;
+    expect(changeInput.HostedZoneId).toBe("Z123EXAMPLE");
+    expect(changeInput.ChangeBatch?.Changes).toHaveLength(3);
+
+    // All actions are UPSERT
+    for (const change of changeInput.ChangeBatch!.Changes!) {
+      expect(change.Action).toBe("UPSERT");
+    }
+
+    // TXT record: name preserved as-is, single ResourceRecord with raw value
+    const txtChange = changeInput.ChangeBatch!.Changes!.find(
+      (c) => c.ResourceRecordSet?.Type === "TXT"
+    );
+    expect(txtChange?.ResourceRecordSet).toMatchObject({
+      Name: "_amazonses.example.com",
+      Type: "TXT",
+      TTL: 300,
+    });
+    // Route53 requires TXT values to be quoted
+    expect(txtChange?.ResourceRecordSet?.ResourceRecords).toEqual([
+      { Value: '"verification-token"' },
+    ]);
+
+    // MX record: priority+host kept as a single Value string (Route53 spec)
+    const mxChange = changeInput.ChangeBatch!.Changes!.find(
+      (c) => c.ResourceRecordSet?.Type === "MX"
+    );
+    expect(mxChange?.ResourceRecordSet?.ResourceRecords).toEqual([
+      { Value: "10 inbound-smtp.us-east-1.amazonaws.com." },
+    ]);
+
+    // CNAME record: trailing dot preserved
+    const cnameChange = changeInput.ChangeBatch!.Changes!.find(
+      (c) => c.ResourceRecordSet?.Type === "CNAME"
+    );
+    expect(cnameChange?.ResourceRecordSet?.ResourceRecords).toEqual([
+      { Value: "tok1.dkim.amazonses.com." },
+    ]);
+  });
+
+  it("skips records that already exist with identical type+name+value", async () => {
+    // Existing record matches input exactly -> no Change emitted -> no
+    // ChangeResourceRecordSetsCommand call (empty ChangeBatch is invalid).
+    route53Mock.on(ListResourceRecordSetsCommand).resolves({
+      ResourceRecordSets: [
+        {
+          Name: "_amazonses.example.com.",
+          Type: "TXT",
+          TTL: 300,
+          ResourceRecords: [{ Value: '"verification-token"' }],
+        },
+      ],
+    });
+
+    const records: DnsProviderRecord[] = [
+      {
+        type: "TXT",
+        name: "_amazonses.example.com",
+        value: "verification-token",
+        ttl: 300,
+      },
+    ];
+
+    const result = await setupDomainDNS("example.com", records);
+
+    expect(result).toEqual([]);
+    expect(
+      route53Mock.commandCalls(ChangeResourceRecordSetsCommand)
+    ).toHaveLength(0);
+  });
+
+  it("emits UPSERT only for the records that differ from existing state", async () => {
+    route53Mock.on(ListResourceRecordSetsCommand).resolves({
+      ResourceRecordSets: [
+        // Identical to one of the inputs (will be skipped).
+        {
+          Name: "_amazonses.example.com.",
+          Type: "TXT",
+          TTL: 300,
+          ResourceRecords: [{ Value: '"verification-token"' }],
+        },
+        // Same name+type as an input but DIFFERENT value (will be UPSERTed).
+        {
+          Name: "example.com.",
+          Type: "TXT",
+          TTL: 300,
+          ResourceRecords: [{ Value: '"v=spf1 -all"' }],
+        },
+      ],
+    });
+    route53Mock.on(ChangeResourceRecordSetsCommand).resolves({
+      ChangeInfo: {
+        Id: "/change/C123",
+        Status: "PENDING",
+        SubmittedAt: new Date(),
+      },
+    });
+
+    const records: DnsProviderRecord[] = [
+      {
+        type: "TXT",
+        name: "_amazonses.example.com",
+        value: "verification-token",
+        ttl: 300,
+      },
+      {
+        type: "TXT",
+        name: "example.com",
+        value: "v=spf1 include:amazonses.com ~all",
+        ttl: 300,
+      },
+    ];
+
+    const result = await setupDomainDNS("example.com", records);
+
+    // Only the differing SPF record is changed.
+    expect(result).toEqual([
+      {
+        type: "TXT",
+        name: "example.com",
+        value: "v=spf1 include:amazonses.com ~all",
+        ttl: 300,
+      },
+    ]);
+
+    const changeCalls = route53Mock.commandCalls(
+      ChangeResourceRecordSetsCommand
+    );
+    expect(changeCalls).toHaveLength(1);
+    expect(changeCalls[0].args[0].input.ChangeBatch?.Changes).toHaveLength(1);
+  });
+
+  it("propagates errors from ChangeResourceRecordSets", async () => {
+    route53Mock.on(ListResourceRecordSetsCommand).resolves({
+      ResourceRecordSets: [],
+    });
+    route53Mock
+      .on(ChangeResourceRecordSetsCommand)
+      .rejects(new Error("InvalidChangeBatch"));
+
+    const records: DnsProviderRecord[] = [
+      {
+        type: "TXT",
+        name: "_amazonses.example.com",
+        value: "verification-token",
+        ttl: 300,
+      },
+    ];
+
+    await expect(setupDomainDNS("example.com", records)).rejects.toThrow(
+      "InvalidChangeBatch"
+    );
+  });
+});

--- a/src/lib/dns-provider.ts
+++ b/src/lib/dns-provider.ts
@@ -1,0 +1,125 @@
+/**
+ * DNS provider abstraction.
+ *
+ * Consumers (`src/lib/domains.ts`, retry-dns route) call into this module
+ * instead of importing a specific provider (`digitalocean.ts`, `route53.ts`)
+ * directly. The active provider is selected by the `DNS_PROVIDER` env var.
+ *
+ * Supported providers:
+ *   - `digitalocean` (default — backward compatible with upstream fork)
+ *   - `route53`
+ *
+ * Adding a new provider: implement `setupDomainDNS` and
+ * `verifyDomainOwnership` in a new module, then extend the union type and
+ * the dispatch switch below.
+ */
+
+import * as digitalocean from "./digitalocean";
+import * as route53 from "./route53";
+
+export type DnsProviderName = "digitalocean" | "route53";
+
+/**
+ * Unified DNS record shape returned by all providers. Each provider's
+ * native record type (e.g. `DODomainRecord`) is normalized to this shape
+ * inside the dispatcher so consumers stay provider-agnostic.
+ */
+export interface DnsProviderRecord {
+  type: string;
+  name: string;
+  value: string;
+  ttl: number;
+}
+
+const DEFAULT_PROVIDER: DnsProviderName = "digitalocean";
+const SUPPORTED_PROVIDERS: readonly DnsProviderName[] = [
+  "digitalocean",
+  "route53",
+];
+
+/**
+ * Resolve the active DNS provider from `DNS_PROVIDER`.
+ *
+ * - Unset / empty -> `digitalocean` (backward compat).
+ * - Case-insensitive match against the supported set.
+ * - Unknown value -> throw (fail-fast: catches typos rather than silently
+ *   falling back to the default and surprising the operator).
+ */
+export function getDnsProviderName(): DnsProviderName {
+  const raw = process.env.DNS_PROVIDER;
+  if (!raw || raw.trim() === "") {
+    return DEFAULT_PROVIDER;
+  }
+
+  const normalized = raw.trim().toLowerCase();
+  if ((SUPPORTED_PROVIDERS as readonly string[]).includes(normalized)) {
+    return normalized as DnsProviderName;
+  }
+
+  throw new Error(
+    `Unsupported DNS_PROVIDER='${raw}'. Supported values: ${SUPPORTED_PROVIDERS.join(
+      ", "
+    )}.`
+  );
+}
+
+/**
+ * Create or update DNS records via the active provider. Returns the
+ * subset of records that were actually applied (created or updated).
+ *
+ * Provider-specific record shapes are normalized to `DnsProviderRecord`
+ * before returning so consumers stay provider-agnostic.
+ */
+export async function setupDomainDNS(
+  domain: string,
+  dnsRecords: DnsProviderRecord[]
+): Promise<DnsProviderRecord[]> {
+  const provider = getDnsProviderName();
+  switch (provider) {
+    case "digitalocean": {
+      const doRecords = await digitalocean.setupDomainDNS(domain, dnsRecords);
+      return doRecords.map(doRecordToDnsProviderRecord);
+    }
+    case "route53": {
+      return route53.setupDomainDNS(domain, dnsRecords);
+    }
+  }
+}
+
+/**
+ * Verify that the active provider considers the domain "owned" (i.e. the
+ * provider can manage DNS records for it). Used as a precondition before
+ * attempting `setupDomainDNS`.
+ */
+export async function verifyDomainOwnership(domain: string): Promise<boolean> {
+  const provider = getDnsProviderName();
+  switch (provider) {
+    case "digitalocean":
+      return digitalocean.verifyDomainOwnership(domain);
+    case "route53":
+      return route53.verifyDomainOwnership(domain);
+  }
+}
+
+/**
+ * DigitalOcean returns native `DODomainRecord` objects (with `data` for
+ * the value). Convert to the unified `DnsProviderRecord` shape.
+ *
+ * Note: DigitalOcean splits MX records into `priority` + host fields.
+ * The host alone is not a complete DNS value, so we re-emit
+ * "PRIORITY HOST" to keep parity with the upstream record shape.
+ */
+function doRecordToDnsProviderRecord(
+  doRecord: digitalocean.DODomainRecord
+): DnsProviderRecord {
+  let value = doRecord.data;
+  if (doRecord.type === "MX" && typeof doRecord.priority === "number") {
+    value = `${doRecord.priority} ${doRecord.data}`;
+  }
+  return {
+    type: doRecord.type,
+    name: doRecord.name,
+    value,
+    ttl: doRecord.ttl,
+  };
+}

--- a/src/lib/domains.ts
+++ b/src/lib/domains.ts
@@ -7,11 +7,7 @@ import {
   enableDomainDkim,
   getDomainDkimTokens,
 } from "./ses";
-import {
-  setupDomainDNS,
-  verifyDomainOwnership,
-  type DODomainRecord,
-} from "./digitalocean";
+import { setupDomainDNS, verifyDomainOwnership } from "./dns-provider";
 import type { Domain } from "./database";
 
 export interface DNSRecord {
@@ -25,7 +21,12 @@ export interface DomainSetupResult {
   domain: Domain;
   dnsRecords: DNSRecord[];
   sesConfigurationSet?: string;
-  digitalOceanRecords?: DNSRecord[];
+  /**
+   * Records that the active DNS provider actually created or updated as
+   * part of this setup call. Provider-specific shapes are normalized in
+   * `dns-provider.ts` before reaching this layer.
+   */
+  dnsProviderRecords?: DNSRecord[];
   setupInstructions: string;
 }
 
@@ -65,16 +66,6 @@ function safeJSONStringify(obj: unknown): string {
     }
     return "[]";
   }
-}
-
-// Helper function to convert DODomainRecord to DNSRecord
-function convertDORecordToDNSRecord(doRecord: DODomainRecord): DNSRecord {
-  return {
-    type: doRecord.type,
-    name: doRecord.name,
-    value: doRecord.data,
-    ttl: doRecord.ttl,
-  };
 }
 
 export async function addDomain(
@@ -123,22 +114,21 @@ export async function addDomain(
       dkimTokens
     );
 
-    // 5. Setup DNS records in Digital Ocean (if configured)
-    let digitalOceanRecords: DNSRecord[] = [];
+    // 5. Setup DNS records via the configured DNS provider (if any)
+    let dnsProviderRecords: DNSRecord[] = [];
     let setupInstructions = "";
 
     try {
-      const isDomainInDO = await verifyDomainOwnership(domainName);
-      if (isDomainInDO) {
-        const doRecords = await setupDomainDNS(domainName, dnsRecords);
-        digitalOceanRecords = doRecords.map(convertDORecordToDNSRecord);
+      const isDomainOwned = await verifyDomainOwnership(domainName);
+      if (isDomainOwned) {
+        dnsProviderRecords = await setupDomainDNS(domainName, dnsRecords);
         setupInstructions =
-          "DNS records have been automatically created in Digital Ocean.";
+          "DNS records have been automatically created via the configured DNS provider.";
       } else {
-        setupInstructions = `Domain not found in Digital Ocean. Please create the DNS records manually or add the domain to your Digital Ocean account first.`;
+        setupInstructions = `Domain not managed by the configured DNS provider. Please create the DNS records manually or add the domain to your DNS provider first.`;
       }
     } catch (error: unknown) {
-      console.warn("Digital Ocean setup failed:", error);
+      console.warn("DNS provider setup failed:", error);
       setupInstructions =
         "DNS records need to be created manually. Please add the following records to your DNS provider:";
     }
@@ -171,7 +161,7 @@ export async function addDomain(
       domain,
       dnsRecords,
       sesConfigurationSet: configurationSet,
-      digitalOceanRecords,
+      dnsProviderRecords,
       setupInstructions,
     };
   } catch (error: unknown) {
@@ -193,7 +183,7 @@ async function verifyAndCompleteExistingDomain(
   let needsUpdate = false;
   const updateFields: Record<string, string> = {};
   let setupInstructions = "";
-  let digitalOceanRecords: DNSRecord[] = [];
+  let dnsProviderRecords: DNSRecord[] = [];
 
   try {
     // 1. Check SES domain status
@@ -276,34 +266,33 @@ async function verifyAndCompleteExistingDomain(
       dkimTokens
     );
 
-    // 5. Check/setup Digital Ocean DNS
+    // 5. Check/setup DNS via the configured DNS provider
     try {
-      const isDomainInDO = await verifyDomainOwnership(domainName);
-      if (isDomainInDO) {
+      const isDomainOwned = await verifyDomainOwnership(domainName);
+      if (isDomainOwned) {
         console.log(
-          `Domain ${domainName} found in Digital Ocean, checking DNS setup...`
+          `Domain ${domainName} managed by configured DNS provider, checking DNS setup...`
         );
         try {
-          const doRecords = await setupDomainDNS(domainName, dnsRecords);
-          digitalOceanRecords = doRecords.map(convertDORecordToDNSRecord);
+          dnsProviderRecords = await setupDomainDNS(domainName, dnsRecords);
           setupInstructions =
-            "DNS records have been verified/updated in Digital Ocean.";
+            "DNS records have been verified/updated via the configured DNS provider.";
         } catch (dnsError: unknown) {
           const dnsErrorMessage =
             dnsError instanceof Error ? dnsError.message : String(dnsError);
           console.warn(`DNS setup failed: ${dnsErrorMessage}`);
           setupInstructions =
-            "DNS records need to be updated manually in Digital Ocean.";
+            "DNS records need to be updated manually in your DNS provider.";
         }
       } else {
-        setupInstructions = `Domain not found in Digital Ocean. Please add the domain to your Digital Ocean account or create DNS records manually.`;
+        setupInstructions = `Domain not managed by the configured DNS provider. Please add the domain to your DNS provider or create DNS records manually.`;
       }
     } catch (error: unknown) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
-      console.warn(`Digital Ocean check failed: ${errorMessage}`);
+      console.warn(`DNS provider check failed: ${errorMessage}`);
       setupInstructions =
-        "Unable to verify Digital Ocean setup. Please check DNS records manually.";
+        "Unable to verify DNS provider setup. Please check DNS records manually.";
     }
 
     // 6. Update database if needed
@@ -336,7 +325,7 @@ async function verifyAndCompleteExistingDomain(
           domain: updatedDomain,
           dnsRecords,
           sesConfigurationSet: configurationSet,
-          digitalOceanRecords,
+          dnsProviderRecords,
           setupInstructions: `Domain already exists. ${setupInstructions}`,
         };
       }
@@ -347,7 +336,7 @@ async function verifyAndCompleteExistingDomain(
       domain: existingDomain,
       dnsRecords,
       sesConfigurationSet: configurationSet,
-      digitalOceanRecords,
+      dnsProviderRecords,
       setupInstructions: `Domain already exists. ${setupInstructions}`,
     };
   } catch (error: unknown) {

--- a/src/lib/route53.ts
+++ b/src/lib/route53.ts
@@ -1,0 +1,243 @@
+/**
+ * AWS Route53 DNS provider.
+ *
+ * Implements the same `setupDomainDNS` / `verifyDomainOwnership` surface
+ * that `digitalocean.ts` exposes, normalized to the unified
+ * `DnsProviderRecord` shape consumed by `dns-provider.ts`.
+ *
+ * Required env:
+ *   - `AWS_HOSTED_ZONE_ID` — the hosted zone in which records are managed.
+ *   - `AWS_REGION` (optional, defaults to `us-east-1`; Route53 is global
+ *     but the SDK still wants a region).
+ *   - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (or any other AWS
+ *     credential resolver supported by the SDK).
+ *
+ * Idempotency: existing records are listed first; only changes that
+ * differ from current state are sent in a single UPSERT ChangeBatch.
+ */
+import {
+  Route53Client,
+  GetHostedZoneCommand,
+  ListResourceRecordSetsCommand,
+  ChangeResourceRecordSetsCommand,
+  type Change,
+  type ResourceRecordSet,
+  type RRType,
+} from "@aws-sdk/client-route-53";
+
+import type { DnsProviderRecord } from "./dns-provider";
+
+const route53Client = new Route53Client({
+  region: process.env.AWS_REGION || "us-east-1",
+});
+
+function getHostedZoneId(): string | undefined {
+  return process.env.AWS_HOSTED_ZONE_ID;
+}
+
+/**
+ * Verify that the configured hosted zone exists and is accessible. The
+ * hosted zone is treated as the source of truth for "which domains do
+ * we own" — operators map subdomains under one or more zones at the
+ * AWS account level.
+ */
+export async function verifyDomainOwnership(
+  domain: string
+): Promise<boolean> {
+  // The hosted zone is the source of truth; the domain argument exists
+  // for parity with other providers (digitalocean.ts uses it directly).
+  // Logged at debug level so it's discoverable but not noisy.
+  void domain;
+  const hostedZoneId = getHostedZoneId();
+  if (!hostedZoneId) {
+    return false;
+  }
+
+  try {
+    const response = await route53Client.send(
+      new GetHostedZoneCommand({ Id: hostedZoneId })
+    );
+    return Boolean(response.HostedZone);
+  } catch (error: unknown) {
+    const errName = (error as { name?: string }).name;
+    if (errName === "NoSuchHostedZone") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/**
+ * Create or update DNS records in the configured hosted zone.
+ *
+ * - Empty input -> no-op (no SDK calls); returns `[]`.
+ * - Lists existing records first; skips inputs that already match
+ *   exactly (same type+name+value+ttl) so the operation is idempotent
+ *   and avoids unnecessary churn.
+ * - All differing records are batched into a single UPSERT
+ *   `ChangeResourceRecordSetsCommand`.
+ *
+ * Returns the unified-shape records that were actually created/updated.
+ */
+export async function setupDomainDNS(
+  domain: string,
+  dnsRecords: DnsProviderRecord[]
+): Promise<DnsProviderRecord[]> {
+  if (dnsRecords.length === 0) {
+    return [];
+  }
+
+  const hostedZoneId = getHostedZoneId();
+  if (!hostedZoneId) {
+    throw new Error(
+      "AWS_HOSTED_ZONE_ID is not set; cannot manage Route53 DNS records."
+    );
+  }
+
+  const existing = await listAllResourceRecordSets(hostedZoneId);
+
+  const changes: Change[] = [];
+  const applied: DnsProviderRecord[] = [];
+
+  for (const record of dnsRecords) {
+    const recordSet = toResourceRecordSet(record);
+    if (recordSetMatches(recordSet, existing)) {
+      console.log(
+        `Route53: ${record.type} ${record.name} already up-to-date, skipping`
+      );
+      continue;
+    }
+    changes.push({ Action: "UPSERT", ResourceRecordSet: recordSet });
+    applied.push(record);
+  }
+
+  if (changes.length === 0) {
+    return [];
+  }
+
+  await route53Client.send(
+    new ChangeResourceRecordSetsCommand({
+      HostedZoneId: hostedZoneId,
+      ChangeBatch: {
+        Comment: `my-resend setup for ${domain}`,
+        Changes: changes,
+      },
+    })
+  );
+
+  return applied;
+}
+
+/**
+ * Page through ListResourceRecordSets to materialize the full record set
+ * for the hosted zone. Hosted zones are typically small for our use
+ * case, but pagination is still required by the API.
+ */
+async function listAllResourceRecordSets(
+  hostedZoneId: string
+): Promise<ResourceRecordSet[]> {
+  const all: ResourceRecordSet[] = [];
+  let startRecordName: string | undefined;
+  let startRecordType: RRType | undefined;
+  let startRecordIdentifier: string | undefined;
+
+  // Cap to avoid runaway loops in pathological cases.
+  for (let i = 0; i < 50; i++) {
+    const response = await route53Client.send(
+      new ListResourceRecordSetsCommand({
+        HostedZoneId: hostedZoneId,
+        StartRecordName: startRecordName,
+        StartRecordType: startRecordType,
+        StartRecordIdentifier: startRecordIdentifier,
+      })
+    );
+    if (response.ResourceRecordSets) {
+      all.push(...response.ResourceRecordSets);
+    }
+    if (!response.IsTruncated) {
+      break;
+    }
+    startRecordName = response.NextRecordName;
+    startRecordType = response.NextRecordType;
+    startRecordIdentifier = response.NextRecordIdentifier;
+  }
+
+  return all;
+}
+
+/**
+ * Map a unified DnsProviderRecord to the Route53 ResourceRecordSet shape.
+ *
+ * - Names: Route53 normalizes to the trailing-dot FQDN form internally.
+ *   We send without the trailing dot; the comparison helper normalizes
+ *   both sides for matching.
+ * - TXT values must be wrapped in double quotes per RFC 1035 / Route53.
+ * - MX values are kept as a single "PRIORITY HOST" string; Route53 also
+ *   accepts that as the ResourceRecord Value verbatim.
+ * - CNAME values keep their trailing dot exactly as supplied.
+ */
+function toResourceRecordSet(record: DnsProviderRecord): ResourceRecordSet {
+  const value =
+    record.type.toUpperCase() === "TXT"
+      ? quoteTxtValue(record.value)
+      : record.value;
+
+  return {
+    Name: record.name,
+    Type: record.type as RRType,
+    TTL: record.ttl,
+    ResourceRecords: [{ Value: value }],
+  };
+}
+
+function quoteTxtValue(value: string): string {
+  // If already quoted, pass through.
+  if (value.startsWith('"') && value.endsWith('"')) {
+    return value;
+  }
+  // Escape any embedded double quotes per Route53 TXT semantics.
+  return `"${value.replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Returns true if the hosted zone already contains a record set matching
+ * the input on type, name, and at least one ResourceRecord value.
+ *
+ * Names are compared with trailing dots stripped (Route53's canonical
+ * form vs our input form). For CNAME/MX values that may include trailing
+ * dots, we strip them on both sides to avoid spurious diffs.
+ */
+function recordSetMatches(
+  candidate: ResourceRecordSet,
+  existing: ResourceRecordSet[]
+): boolean {
+  const candName = stripTrailingDot(candidate.Name ?? "");
+  const candType = candidate.Type;
+  const candValues = (candidate.ResourceRecords ?? []).map((r) =>
+    normalizeValue(r.Value ?? "", candType)
+  );
+
+  return existing.some((existingSet) => {
+    if (existingSet.Type !== candType) return false;
+    if (stripTrailingDot(existingSet.Name ?? "") !== candName) return false;
+    const existingValues = (existingSet.ResourceRecords ?? []).map((r) =>
+      normalizeValue(r.Value ?? "", existingSet.Type)
+    );
+    // Match if every candidate value is present in the existing set.
+    return candValues.every((v) => existingValues.includes(v));
+  });
+}
+
+function stripTrailingDot(value: string): string {
+  return value.endsWith(".") ? value.slice(0, -1) : value;
+}
+
+function normalizeValue(value: string, type: RRType | undefined): string {
+  // For CNAME and MX, the trailing dot is semantically a no-op when
+  // compared as DNS data; strip it to make idempotency robust against
+  // mixed-form inputs.
+  if (type === "CNAME" || type === "MX") {
+    return stripTrailingDot(value);
+  }
+  return value;
+}


### PR DESCRIPTION
## 요약
- `DNS_PROVIDER` 추상화 (`src/lib/dns-provider.ts`) 도입 — DigitalOcean (default) 또는 AWS Route53 으로 디스패치.
- Route53 provider (`src/lib/route53.ts`) 추가 — `@aws-sdk/client-route-53` 사용, 멱등 UPSERT 배치.
- `src/lib/domains.ts` 와 retry-dns 라우트가 직접 DigitalOcean import 를 떼어내고 추상화 통과 — consumer 는 어느 provider 가 활성인지 모름.

Closes #4.

## 상세
DNS provider 는 도메인 셋업 흐름에 마지막으로 남아있던 hard-coded 외부 의존성이었음. AWS 인프라에서 운영하는 operator 는 DKIM / SPF / DMARC 레코드를 DigitalOcean 대신 Route53 에 등록하고 싶어함 — 이전엔 DO 만 옵션. 디스패처는 `DNS_PROVIDER` (`digitalocean` | `route53`, upstream fork backward compatibility 위해 default `digitalocean`) 를 읽어 `setupDomainDNS` 와 `verifyDomainOwnership` 양쪽을 적절히 라우팅. `DODomainRecord -> DNSRecord` 변환은 consumer 에서 디스패처로 이동하여 미래의 provider 는 unified shape 만 반환하면 됨.

`route53.ts` 는 기존 record set 을 list 하고 diff 를 계산한 뒤 단일 `ChangeResourceRecordSets` UPSERT 배치로 제출 — CNAME trailing dot 보존 + RFC 1035 에 맞춰 TXT 값 quoting. `verifyDomainOwnership` 은 `AWS_HOSTED_ZONE_ID` 에 대한 `GetHostedZone` 으로 충족; 본 단계에서는 domain 인자 의도적으로 미사용 (single-zone operator 만 — `ListHostedZonesByName` 자동 탐지는 후속).

`DomainSetupResult.digitalOceanRecords` 가 `dnsProviderRecords` 로 rename (클라이언트 측 참조 0건, 안전 rename). API 사용자 노출 메시지의 "DigitalOcean" hard-code 는 "configured DNS provider" 로 일반화.

`jest.setup.env.js` 추가 — `digitalocean.ts` 가 module-load 시점에 `DO_API_TOKEN` 을 캡처하므로 per-test env mutation 이 너무 늦음. setup 파일이 `DO_API_TOKEN` 과 `AWS_REGION` 을 시드하여 모든 suite 가 모듈을 unconditionally import 가능; 디스패처를 다루는 테스트는 `DNS_PROVIDER` 와 `AWS_HOSTED_ZONE_ID` 를 자체 관리.

통합 suite 가 provider 격리를 입증: `DNS_PROVIDER=digitalocean` 일 때 `addDomain` 흐름이 axios mock 만 호출하고 Route53 호출 0; `DNS_PROVIDER=route53` 일 때 Route53 mock 만 호출하고 axios 호출 0.

## 변경 파일
```
docs/plan/
└── 002-route53-dns-provider.md         # 신규 — plan 문서
src/lib/
├── dns-provider.ts                     # 신규 — env 디스패치 추상화
├── route53.ts                          # 신규 — @aws-sdk/client-route-53 wrapper
├── domains.ts                          # dns-provider 사용; digitalOceanRecords → dnsProviderRecords rename
└── __tests__/
    ├── dns-provider.test.ts            # 신규 — env 디스패치 (10 tests)
    ├── route53.test.ts                 # 신규 — Route53 SDK surface (10 tests)
    └── domains-dns-integration.test.ts # 신규 — provider 격리 (2 tests)
src/app/api/domains/[id]/retry-dns/
└── route.ts                            # dns-provider 사용; 메시지 일반화
jest.config.js                           # setupFiles 등록
jest.setup.env.js                        # module-load 전 DO_API_TOKEN / AWS_REGION 시드
package.json                             # @aws-sdk/client-route-53 추가
package-lock.json                        # lock 갱신
```

## 커밋
- [`7b3e43e`](https://github.com/Orchemi/my-resend/commit/7b3e43e) docs(plan): add 002 Route53 DNS provider plan
- [`6b36c3b`](https://github.com/Orchemi/my-resend/commit/6b36c3b) feat(dns): add Route53 provider behind a DNS_PROVIDER abstraction
- [`16ff8fb`](https://github.com/Orchemi/my-resend/commit/16ff8fb) refactor(domains): consume dns-provider abstraction

## 테스트 계획
- [x] `npm run lint` — warning/error 0
- [x] `npm test -- --testPathPatterns='src/lib'` — 7 suites / 105 tests 통과 (기존 ses, notifications, waitlist, pricing-calculator 회귀 0)
- [x] `npm run build` — production build OK (typecheck strict, 모든 라우트 컴파일)
- [x] `domains-dns-integration.test.ts` 로 provider 격리 검증