### PR TITLE
문서 정비: OSS 가시성 정리 + 한국어 README parity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,16 +4,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-FreeResend is a self-hosted, open-source alternative to Resend for sending transactional emails. It provides 100% Resend-compatible API using Amazon SES for email delivery, with optional Digital Ocean DNS automation for domain setup.
+MyResend is a self-hosted, open-source mail gateway with a Resend-compatible API. It uses Amazon SES as the delivery backend and supports automatic DNS record management through either DigitalOcean DNS or AWS Route53 (selectable at runtime via `DNS_PROVIDER`).
+
+The project is a hard fork of [eibrahim/freeresend](https://github.com/eibrahim/freeresend) (MIT). Attribution and the divergence boundary are documented in `NOTICE`.
 
 **Key Technologies:**
-- Next.js 15 (App Router)
-- TypeScript
-- PostgreSQL (direct connection, migrated from Supabase)
-- Amazon SES SDK v3
-- Digital Ocean API
-- JWT authentication
-- bcryptjs for password hashing
+- Next.js 15 (App Router, Turbopack dev)
+- React 19 + TypeScript 5
+- PostgreSQL (direct connection via `pg`, no ORM)
+- AWS SES v2 SDK (`@aws-sdk/client-sesv2`)
+- AWS Route53 SDK (`@aws-sdk/client-route-53`) — optional DNS provider
+- DigitalOcean API (axios) — optional DNS provider
+- Tailwind CSS v4
+- JWT authentication, bcryptjs for password hashing
+- Jest + ts-jest + `aws-sdk-client-mock` for unit tests
 
 ## Development Commands
 
@@ -26,66 +30,82 @@ npm run build       # Build for production
 npm start           # Start production server
 
 # Code Quality
-npm run lint        # Run ESLint
+npm run lint        # Run ESLint (next/core-web-vitals)
 
-# Testing
-node test-email.js  # Comprehensive email testing (API + Resend SDK)
-./test-curl.sh      # Quick cURL-based API test
+# Testing (Jest)
+npm test            # Run all unit + integration tests
+npm run test:watch  # Re-run on change
+npm run test:coverage
 ```
+
+There are no `node test-email.js` / `./test-curl.sh` scripts in active use — those are upstream artifacts. The Jest suite under `src/lib/__tests__/` and `src/components/__tests__/` is the source of truth for verification.
 
 ## Architecture Overview
 
 ### Core Structure
-- **API Layer**: Next.js App Router API routes (`/src/app/api/`)
-- **Business Logic**: Modular libraries in `/src/lib/`
-- **Database**: Direct PostgreSQL with connection pooling
-- **Frontend**: React dashboard components in `/src/components/`
+- **API Layer**: Next.js App Router API routes (`src/app/api/`)
+- **Business Logic**: Modular libraries in `src/lib/`
+- **DNS Provider Abstraction**: `src/lib/dns-provider.ts` (dispatched by `DNS_PROVIDER`)
+- **Database**: Direct PostgreSQL via `pg` connection pool
+- **Frontend**: React dashboard components in `src/components/`
 
 ### Database Architecture
-The project uses **direct PostgreSQL** (not Supabase) with:
-- Connection pooling via `pg` package
+The project uses **direct PostgreSQL** (no ORM, no Supabase) with:
+- Connection pooling via the `pg` package
 - Transaction support
 - Auto-updating timestamps via triggers
 - UUID primary keys
 - JSONB fields for flexible data (DNS records, email arrays)
 
 **Key Tables:**
-- `users` - Admin user accounts
-- `domains` - Email sending domains with SES integration
-- `api_keys` - API authentication keys (bcrypt hashed)
-- `email_logs` - All sent email records with delivery status
-- `webhook_events` - SES delivery event processing
+- `users` — admin user accounts
+- `domains` — email sending domains with SES integration
+- `api_keys` — API authentication keys (bcrypt-hashed)
+- `email_logs` — all sent email records with delivery status
+- `webhook_events` — SES delivery event processing
+
+The schema lives in `database.sql`; there is no migration framework — apply once on first deploy.
 
 ### Integration Architecture
 
-**Amazon SES Integration** (`/src/lib/ses.ts`):
-- Domain verification and DKIM setup
-- Email sending (simple and raw with attachments)
-- Configuration sets and webhook handling
-- Bounce/complaint processing
+**Amazon SES** (`src/lib/ses.ts`):
+- v2 SDK (`@aws-sdk/client-sesv2`) — `SendEmailCommand`, `CreateEmailIdentityCommand`, `GetEmailIdentityCommand`, `PutEmailIdentityDkimAttributesCommand`, `DeleteEmailIdentityCommand`, `CreateConfigurationSetCommand`
+- External function signatures preserve the v1-era return shapes so consumers (`domains.ts`, API routes) stay provider-detail-free
+- `verifyDomain` swallows `AlreadyExistsException` and falls through to `GetEmailIdentity` to keep idempotency
 
-**Digital Ocean DNS** (`/src/lib/digitalocean.ts`):
-- Automatic DNS record creation (TXT, MX, SPF, DMARC, DKIM)
-- Domain validation
-- Error handling and manual fallback
+**DNS Provider Abstraction** (`src/lib/dns-provider.ts`):
+- Selected at runtime by `DNS_PROVIDER` (`digitalocean` | `route53`, default `digitalocean`)
+- Exposes `setupDomainDNS(domain, dnsRecords)` and `verifyDomainOwnership(domain)`
+- Normalises every provider's native record shape to `DnsProviderRecord { type, name, value, ttl }` so consumers stay provider-agnostic
+- Unknown `DNS_PROVIDER` values throw (fail-fast) — silent fallback would mask typos
 
-**API Key System** (`/src/lib/api-keys.ts`):
-- Format: `frs_{keyId}_{secretPart}` 
-- bcrypt hashing with prefix for identification
+**DigitalOcean DNS** (`src/lib/digitalocean.ts`):
+- axios-based client targeting the DO v2 API
+- Domain validation, record creation/update/delete, MX priority handling, exponential backoff for 429s
+
+**AWS Route53** (`src/lib/route53.ts`):
+- v3 SDK (`@aws-sdk/client-route-53`)
+- Idempotent UPSERT via a single `ChangeResourceRecordSetsCommand` batch — lists existing records first and skips no-op rows
+- Preserves CNAME trailing dots and quotes TXT values per RFC 1035
+- Requires `AWS_HOSTED_ZONE_ID`; without it `verifyDomainOwnership` returns `false` and `setupDomainDNS` throws
+
+**API Key System** (`src/lib/api-keys.ts`):
+- Format: `mrs_{keyId}_{secretPart}`
+- bcrypt hashing with the `mrs_` prefix preserved for identification
 - Domain-scoped permissions
 
 ## API Design Patterns
 
 ### Resend Compatibility
-The project maintains **100% compatibility** with Resend SDK by:
-- Matching exact API endpoint structure (`/api/emails`)
-- Supporting same request/response formats
-- Using environment variable `RESEND_BASE_URL` for endpoint override
+The project maintains 100% compatibility with the Resend Node.js SDK by:
+- Matching the exact API endpoint structure (`/api/emails`)
+- Supporting the same request/response formats
+- Honouring `RESEND_BASE_URL` so existing Resend users can swap without code changes
 
 ### Authentication Flow
-1. **Admin Login**: JWT tokens via `/api/auth/login`
-2. **API Keys**: Bearer token authentication for email operations
-3. **Middleware**: `withAuth()` and `withApiKeyAuth()` helpers
+1. **Admin login** — JWT tokens via `POST /api/auth/login`
+2. **API keys** — Bearer token authentication for email operations
+3. **Middleware** — `withAuth()` and `withApiKeyAuth()` helpers in `src/lib/middleware.ts`
 
 ### Error Handling Pattern
 Consistent error responses with:
@@ -111,17 +131,23 @@ const result = await transaction(async (client) => {
 ```
 
 ### API Route Structure
-Follow the established pattern in `/src/app/api/`:
+Follow the established pattern in `src/app/api/`:
 - Use proper HTTP methods (GET, POST, DELETE)
 - Apply authentication middleware
 - Return consistent JSON responses
 - Handle errors gracefully
 
 ### Component Organization
-- **Dashboard.tsx**: Main container with tab switching
-- **[Feature]Tab.tsx**: Individual feature components
-- **LoginForm.tsx**: Authentication handling
-- Use React hooks and context for state management
+- `Dashboard.tsx` — main container with tab switching
+- `[Feature]Tab.tsx` — individual feature components
+- `LoginForm.tsx` — authentication handling
+- React hooks + context for state management
+
+### Testing
+- Unit tests live next to the code under `__tests__/` directories
+- AWS SDK calls are mocked with [`aws-sdk-client-mock`](https://github.com/m-radzikowski/aws-sdk-client-mock); axios is mocked via `jest.mock("axios", ...)`
+- Tests must never hit real AWS / DigitalOcean / SMTP endpoints
+- DNS provider abstraction is verified by an integration suite that asserts provider isolation: with `DNS_PROVIDER=digitalocean` only axios is exercised, with `DNS_PROVIDER=route53` only the Route53 client
 
 ## Environment Configuration
 
@@ -135,8 +161,14 @@ AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=...
 AWS_SECRET_ACCESS_KEY=...
 
-# Digital Ocean (optional)
+# DNS provider selection
+DNS_PROVIDER=digitalocean        # or "route53"; defaults to "digitalocean"
+
+# DigitalOcean (required when DNS_PROVIDER=digitalocean)
 DO_API_TOKEN=...
+
+# Route53 (required when DNS_PROVIDER=route53)
+AWS_HOSTED_ZONE_ID=...           # the hosted zone that owns the sending domains
 
 # Security
 NEXTAUTH_SECRET=...
@@ -146,74 +178,54 @@ ADMIN_EMAIL=...
 ADMIN_PASSWORD=...
 ```
 
-## Testing Strategy
-
-**Primary Test Script**: `node test-email.js`
-- Tests direct API calls
-- Validates Resend SDK compatibility  
-- Checks email log functionality
-- Sends actual test emails
-
-**Quick Test**: `./test-curl.sh`
-- Fast cURL-based validation
-- Useful for CI/CD integration
-
-## Database Migration Notes
-
-The project recently migrated from Supabase to direct PostgreSQL:
-- Connection pooling replaces Supabase client
-- Row Level Security removed (handled in application layer)
-- Direct SQL queries replace Supabase query builder
-- Types maintained for compatibility
-
 ## Domain Setup Workflow
 
-1. **Add Domain**: POST `/api/domains` with domain name
-2. **DNS Records**: Auto-created (DO) or manual setup required
-3. **SES Verification**: Automatic domain verification with AWS
-4. **DKIM Setup**: Automatic DKIM key generation and DNS records
-5. **API Key Creation**: Generate keys for verified domains only
-6. **Email Sending**: Use API keys with Resend-compatible endpoints
+1. **Add domain** — `POST /api/domains` with the domain name
+2. **DNS records generated** — `generateDNSRecords()` in `src/lib/ses.ts` produces TXT (SES verification), MX, SPF, DMARC, and DKIM CNAMEs
+3. **DNS provider applies records** — `dns-provider.setupDomainDNS()` dispatches to DigitalOcean or Route53 based on `DNS_PROVIDER`
+4. **SES verification** — `verifyDomain()` (`CreateEmailIdentity` + `GetEmailIdentity`) registers the domain with SES; `getDomainVerificationStatus()` is polled until success
+5. **DKIM tokens** — `enableDomainDkim()` activates DKIM signing; tokens flow back into the DNS records on a retry
+6. **API key creation** — generate keys for verified domains only
+7. **Email sending** — use API keys with the Resend-compatible endpoints (`POST /api/emails`)
 
 ## Common Development Tasks
 
 ### Adding New API Endpoints
-1. Create route file in `/src/app/api/[path]/route.ts`
-2. Add business logic to appropriate `/src/lib/` file
-3. Apply authentication middleware if needed
-4. Update types in `/src/lib/database.ts` if database changes required
+1. Create the route file under `src/app/api/[path]/route.ts`
+2. Add business logic to the appropriate `src/lib/` module
+3. Apply authentication middleware
+4. Update types in `src/lib/database.ts` if a schema change is required
 
 ### Database Schema Changes
-1. Update `/database.sql` with new schema
-2. Update TypeScript interfaces in `/src/lib/database.ts`
-3. Test with `node test-email.js`
+1. Update `database.sql` with the new schema
+2. Update TypeScript interfaces in `src/lib/database.ts`
+3. Apply via `psql ... -f database.sql` (no migration framework)
 
-### Testing Email Functionality
-Always test with real email addresses and verify:
-- Email delivery via AWS SES console
-- Webhook processing for delivery events
-- Email logs in dashboard
-- API key authentication
+### Adding a New DNS Provider
+1. Implement `setupDomainDNS(domain, dnsRecords)` and `verifyDomainOwnership(domain)` in a new module under `src/lib/`
+2. Extend the `DnsProviderName` union and the dispatch switch in `src/lib/dns-provider.ts`
+3. Add unit tests using whatever client mock is appropriate (`aws-sdk-client-mock` for AWS, `jest.mock` for axios-based providers)
+4. Add the new provider to the integration suite to keep the isolation guarantee
 
 ## Security Considerations
 
-- All passwords are bcrypt hashed (rounds: 12)
-- API keys are hashed with identifiable prefixes
+- All passwords are bcrypt-hashed (rounds: 12)
+- API keys are hashed with identifiable `mrs_` prefixes
 - JWT tokens for dashboard authentication
-- Direct database queries use parameterized statements
+- Database queries use parameterised statements
 - Environment variables for all sensitive data
 - CORS handling for cross-origin requests
 
 ## Production Deployment
 
-The application supports multiple deployment methods:
-- **Vercel**: Serverless deployment (recommended)
-- **Docker**: Containerized deployment
-- **Traditional**: Node.js server deployment
+The application is container-friendly via the included `Dockerfile` and runs on any platform that supports a long-lived Node.js process:
+- Container PaaS (Docker, Dokku, Coolify, Fly.io, Railway, ...)
+- Kubernetes (sample manifests live under `k8s/`)
+- Managed Node.js hosting (Vercel, Render, etc. — webhook endpoints may need extra configuration on serverless platforms)
 
 Key production requirements:
-- PostgreSQL database (hosted)
-- AWS SES out of sandbox mode
+- A managed or self-hosted PostgreSQL instance
+- AWS SES out of sandbox mode for the sending region
 - SSL certificates for HTTPS
-- Environment variables configured
-- Database schema initialized
+- Environment variables configured (see above)
+- Database schema initialised via `database.sql`

--- a/NOTICE
+++ b/NOTICE
@@ -41,8 +41,8 @@ The following changes distinguish my-resend from the upstream project
   * AWS SDK migration: SES v1 (`@aws-sdk/client-ses`)
     -> SES v2 (`@aws-sdk/client-sesv2`)
   * DNS automation: DigitalOcean DNS only
-    -> DigitalOcean DNS + AWS Route53 (provider-pluggable)
+    -> DigitalOcean DNS + AWS Route53, selectable at runtime via the
+    `DNS_PROVIDER` environment variable
   * API key prefix: `frs_` -> `mrs_`
-  * Branding, README localization (KO), and documentation rewrite
-  * Default deployment target: home-server (Dokku) with horbis infra
-    conventions
+  * Branding, README localization (English + Korean), and full
+    documentation rewrite

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,47 +2,447 @@
 
 > 🌐 **언어**: [English](./README.md) · **한국어**
 
-**Resend SDK 와 호환되는 self-hosted 메일 게이트웨이.**
+**Resend 호환 API 를 제공하는 self-hosted 오픈소스 메일 게이트웨이.**
 
-my-resend 는 [eibrahim/freeresend](https://github.com/eibrahim/freeresend) (MIT) 의 hard fork 입니다. 출처와 분기 시점은 [NOTICE](./NOTICE) 를 참조하세요. AWS SES 를 backend 로 사용하며 (SES v2 마이그레이션 진행 중), DNS 자동화는 DigitalOcean 과 AWS Route53 양쪽을 지원합니다. Resend Node SDK 와 호환되므로 기존 Resend 사용자는 환경변수 `RESEND_BASE_URL` 만 바꿔서 이관할 수 있습니다.
-
-> ⚠️ **상태**: my-resend 는 upstream 으로부터 활발히 분기 중입니다. 브랜딩 정리, SES v2 마이그레이션, Route53 지원은 작업 진행 중이며, 그 전까지는 README 가 기본적으로 upstream 동작을 설명합니다.
-
----
+my-resend 는 [eibrahim/freeresend](https://github.com/eibrahim/freeresend) (MIT) 의 hard fork 입니다. 출처와 분기 시점은 [NOTICE](./NOTICE) 를 참조하세요. 메일 발송은 Amazon SES (v2 SDK) 를 사용하며, DNS 레코드는 DigitalOcean DNS 또는 AWS Route53 으로 자동 등록할 수 있습니다 — 활성 provider 는 `DNS_PROVIDER` 환경변수로 선택합니다. HTTP API 는 Resend Node.js SDK 와 호환되므로 기존 Resend 사용자는 `RESEND_BASE_URL` 환경변수만 변경하여 이관할 수 있습니다.
 
 ## 주요 기능
 
-- 🚀 **Resend SDK 100% 호환** — `RESEND_BASE_URL` 환경변수만 바꾸면 기존 코드 변경 없이 이관
-- 🏠 **Self-hosted** — 메일 인프라를 직접 통제, 발송 비용을 SES 단가($0.10/1000건)로 회수
-- 📧 **Amazon SES 연동** — DKIM 자동 서명, 안정적인 deliverability
-- 🌐 **DNS 자동 등록** — DigitalOcean DNS / AWS Route53 (provider-pluggable, 진행 중)
-- 🔐 **DKIM 인증** — DKIM 키 자동 생성 및 DNS 레코드 자동 등록
-- 🔑 **API key 관리** — 도메인별 다중 API key 발급, prefix `mrs_` (예정)
-- 📊 **발송 로그** — 모든 발송 건의 전달 상태와 로그 추적
-- 🎯 **도메인 verify** — SES 도메인 인증 자동화
-- 🔒 **보안** — JWT 인증 + 견고한 API key 검증
-- 🐳 **Docker 지원** — Dockerfile 포함, Docker / Dokku / Fly.io / Coolify / k8s 등 컨테이너 호스팅 환경에서 자유롭게 자체 호스팅 가능
+- 🚀 **Resend SDK 100% 호환** — `RESEND_BASE_URL` 환경변수만 변경하면 애플리케이션 코드 변경 없이 drop-in 교체
+- 🏠 **Self-hosted** — 메일 인프라를 직접 통제
+- 📧 **Amazon SES 연동 (v2 SDK)** — `SendEmailCommand`, verify 상태와 DKIM 속성을 한 번에 조회하는 통합 identity API
+- 🌐 **Pluggable DNS 자동화** — DigitalOcean 또는 AWS Route53, `DNS_PROVIDER` 로 선택. 새 provider 추가는 새 모듈 1개 + switch case 1개로 가능
+- 🔐 **DKIM 인증** — DKIM 키 자동 생성과 DNS 레코드 자동 등록
+- 🔑 **API key 관리** — 도메인별 다중 `mrs_` prefix API key 발급, bcrypt 해싱 저장
+- 📊 **발송 로그** — 모든 발송 건의 전달 상태와 webhook 이벤트 추적
+- 🎯 **도메인 verify** — SES 도메인 인증 자동화 + 멱등 재시도
+- 🔒 **보안** — JWT 기반 대시보드 인증, bcrypt 비밀번호 해싱, 매개변수화 SQL
+- 🐳 **컨테이너 친화적** — Dockerfile 포함; Docker / Dokku / Coolify / Fly.io / Kubernetes 등 Node.js 장기 실행 프로세스를 지원하는 모든 호스트에서 동작
+- 🧪 **테스트** — Jest 단위 + 통합 테스트로 SES, DNS provider, Route53 surface 검증 (`aws-sdk-client-mock` 사용, CI 에서 라이브 AWS 호출 없음)
 
 ## 빠른 시작
 
-영어 README 의 [Quick Start](./README.md#quick-start) 섹션을 참조하세요. 본 한국어 문서는 추후 단계별 배포 가이드(예: AWS SES 인증 + Route53 자동 등록 흐름) 가 정리되는 대로 확장될 예정입니다.
+### 사전 요구사항
 
-## upstream 과의 차이
+- Node.js 20 이상
+- PostgreSQL 데이터베이스 (로컬 또는 호스팅)
+- 발송 region 에서 SES 사용이 가능한 AWS 계정
+- DNS 자동화용 **DigitalOcean** 또는 **AWS Route53** 계정 (선택사항 — 수동 DNS 레코드 생성도 가능)
 
-자세한 변경 사항은 [NOTICE](./NOTICE) 의 *Planned Divergence* 항목을 참조하세요. 요약:
+### 설치
 
-| 영역 | upstream (freeresend) | my-resend |
-|---|---|---|
-| AWS SDK | SES v1 (`@aws-sdk/client-ses`) | SES v2 (`@aws-sdk/client-sesv2`, 진행 중) |
-| DNS 자동화 | DigitalOcean DNS only | DigitalOcean + AWS Route53 (provider-pluggable, 진행 중) |
-| API key prefix | `frs_` | `mrs_` (진행 중) |
-| 문서 언어 | English | English + 한국어 |
-| 배포 타깃 | 일반 호스팅 | 컨테이너 자체 호스팅 (Docker / Dokku / Fly.io / Coolify / k8s 등 자유) |
+1. **클론 및 의존성 설치:**
+
+```bash
+git clone https://github.com/Orchemi/my-resend.git
+cd my-resend
+npm install
+```
+
+2. **환경변수 설정:**
+
+```bash
+cp .env.local.example .env.local
+```
+
+`.env.local` 편집:
+
+```env
+# Next.js
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=your-super-secret-jwt-key-here
+
+# 데이터베이스 (PostgreSQL)
+DATABASE_URL=postgresql://username:password@hostname:port/database
+
+# AWS SES
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=your-aws-access-key
+AWS_SECRET_ACCESS_KEY=your-aws-secret-key
+
+# DNS provider 선택 (기본값: digitalocean)
+DNS_PROVIDER=digitalocean
+
+# DigitalOcean DNS (DNS_PROVIDER=digitalocean 일 때 필수)
+DO_API_TOKEN=your-digitalocean-api-token
+
+# AWS Route53 (DNS_PROVIDER=route53 일 때 필수)
+# AWS_HOSTED_ZONE_ID=Z0123456789ABCDEFGHIJ
+
+# 관리자
+ADMIN_EMAIL=admin@yourdomain.com
+ADMIN_PASSWORD=your-secure-admin-password
+```
+
+3. **데이터베이스 초기화:**
+
+PostgreSQL 인스턴스에 `database.sql` 스키마를 적용합니다:
+
+```bash
+psql "$DATABASE_URL" -f database.sql
+```
+
+4. **개발 서버 시작:**
+
+```bash
+npm run dev
+```
+
+`http://localhost:3000` 에 접속하여 관리자 계정으로 로그인합니다.
+
+## AWS SES 셋업
+
+1. **AWS SES 계정 verify:**
+   - 발송 region 의 AWS SES 콘솔을 엽니다
+   - verify 되지 않은 수신자에게도 발송하려면 production access 를 신청합니다
+
+2. **SES v2 권한이 부여된 IAM user 생성:**
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ses:SendEmail",
+        "ses:CreateEmailIdentity",
+        "ses:GetEmailIdentity",
+        "ses:DeleteEmailIdentity",
+        "ses:PutEmailIdentityDkimAttributes",
+        "ses:CreateConfigurationSet"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+> **참고**: my-resend 는 SES v2 API (`@aws-sdk/client-sesv2`) 를 사용합니다. 위 액션은 레거시 v1 액션 (`ses:VerifyDomainIdentity` / `ses:GetIdentityVerificationAttributes` / `ses:VerifyDomainDkim` / `ses:GetIdentityDkimAttributes`) 의 v2 대응입니다.
+
+## DNS Provider 셋업
+
+발송 도메인을 호스팅하는 provider 를 선택합니다. 활성 provider 는 `DNS_PROVIDER` 로 결정되며, 기본값은 upstream fork 와의 backward compatibility 를 위해 `digitalocean` 입니다. `DNS_PROVIDER` 가 알 수 없는 값이면 startup 시 throw — 오타가 silent 로 default 에 폴백되는 것을 방지합니다.
+
+### 옵션 A — DigitalOcean DNS
+
+1. **Domains** 와 **Domain Records** 에 대한 **Read & Write** 권한이 있는 DigitalOcean API 토큰을 생성합니다
+2. 발송 도메인이 DigitalOcean DNS 관리에 등록되어 있는지 확인합니다
+3. 환경변수 설정:
+   ```env
+   DNS_PROVIDER=digitalocean
+   DO_API_TOKEN=your-digitalocean-api-token
+   ```
+
+### 옵션 B — AWS Route53
+
+1. 발송 도메인의 hosted zone 을 생성하거나 기존 zone 을 선택합니다
+2. 동일 IAM user (또는 별도 user) 에 Route53 statement 를 추가합니다:
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Action": [
+           "route53:GetHostedZone",
+           "route53:ListResourceRecordSets",
+           "route53:ChangeResourceRecordSets"
+         ],
+         "Resource": "arn:aws:route53:::hostedzone/Z0123456789ABCDEFGHIJ"
+       }
+     ]
+   }
+   ```
+3. 환경변수 설정:
+   ```env
+   DNS_PROVIDER=route53
+   AWS_HOSTED_ZONE_ID=Z0123456789ABCDEFGHIJ
+   # AWS_REGION / AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY 는 SES 와 공유
+   ```
+
+어느 provider 도 설정되지 않은 경우, my-resend 는 DNS 레코드를 생성하여 대시보드에 표시하므로 수동으로 등록할 수 있습니다.
+
+## Resend SDK 와 함께 사용하기
+
+my-resend 는 [Resend Node.js SDK](https://github.com/resend/resend-node) 와 **100% 호환**됩니다.
+
+### 방법 1: 환경변수 (권장)
+
+`RESEND_BASE_URL` 환경변수를 설정합니다:
+
+```bash
+export RESEND_BASE_URL="https://your-my-resend-domain.com/api"
+```
+
+이후 Resend SDK 를 평소처럼 사용하면 됩니다:
+
+```javascript
+import { Resend } from "resend";
+
+// 코드 변경 없음 — my-resend API key 가 Resend SDK 에서 동작합니다
+const resend = new Resend("your-my-resend-api-key");
+
+const { data, error } = await resend.emails.send({
+  from: "onboarding@yourdomain.com",
+  to: ["user@example.com"],
+  subject: "Hello World",
+  html: "<strong>it works!</strong>",
+});
+```
+
+### 방법 2: 직접 API 호출
+
+```javascript
+const response = await fetch("https://your-my-resend-domain.com/api/emails", {
+  method: "POST",
+  headers: {
+    Authorization: "Bearer your-my-resend-api-key",
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    from: "onboarding@yourdomain.com",
+    to: ["user@example.com"],
+    subject: "Hello World",
+    html: "<strong>it works!</strong>",
+  }),
+});
+```
+
+## API 엔드포인트
+
+### 인증
+
+- `POST /api/auth/login` — 이메일/비밀번호 로그인
+- `GET /api/auth/me` — 현재 사용자 정보 조회
+
+### 도메인
+
+- `GET /api/domains` — 모든 도메인 목록
+- `POST /api/domains` — 새 도메인 추가 (활성 provider 로 SES verify + DNS 레코드 생성을 시작)
+- `DELETE /api/domains/{id}` — 도메인 삭제
+- `POST /api/domains/{id}/verify` — SES verify 상태 재확인
+- `POST /api/domains/{id}/retry-dns` — 활성 provider 로 DNS 레코드 재적용
+
+### API key
+
+- `GET /api/api-keys` — API key 목록
+- `POST /api/api-keys` — 새 API key 생성
+- `DELETE /api/api-keys/{id}` — API key 삭제
+
+### 메일 (Resend 호환)
+
+- `POST /api/emails` — 메일 발송
+- `GET /api/emails/logs` — 발송 로그 조회
+- `GET /api/emails/{id}` — 특정 메일 조회
+
+### Webhook
+
+- `POST /api/webhooks/ses` — SES webhook 엔드포인트 (delivery / bounce / complaint 이벤트)
+
+## 도메인 셋업 절차
+
+1. my-resend 대시보드에서 **도메인을 추가**합니다
+2. **DNS 레코드** 가 생성되며, DNS provider 가 설정되어 있으면 자동 적용되고 그렇지 않으면 수동 등록용으로 표시됩니다:
+   - **TXT 레코드** — `_amazonses.yourdomain.com` (SES 도메인 verify)
+   - **MX 레코드** — `yourdomain.com` (SES 통한 메일 수신)
+   - **SPF 레코드** — `yourdomain.com` (sender policy framework)
+   - **DMARC 레코드** — `_dmarc.yourdomain.com` (이메일 인증 정책)
+   - **DKIM 레코드** — `*._domainkey.yourdomain.com` 의 CNAME 3개 (이메일 서명)
+3. **도메인 verify** — DNS 레코드가 propagate 되면 "Check Verification" 버튼을 클릭합니다 (백그라운드 polling 도 동시 진행)
+4. **API key 생성** — verify 된 도메인에 대해 API key 를 발급합니다
+5. **발송 시작** — my-resend 또는 Resend SDK 로 API key 를 사용해 메일을 발송합니다
+
+## 셋업 테스트
+
+본 프로젝트는 Jest 테스트 스위트를 포함합니다. 단위 + 통합 수준의 테스트만 있으며, 라이브 AWS / DigitalOcean 엔드포인트를 호출하지 않습니다 (`aws-sdk-client-mock` 과 `jest.mock("axios", ...)` 으로 클라이언트를 mock 처리).
+
+```bash
+npm test                    # 전체 테스트 실행
+npm run test:watch          # 변경 시 재실행
+npm run test:coverage       # 커버리지 리포트
+```
+
+`src/lib/__tests__/domains-dns-integration.test.ts` 의 통합 테스트는 provider 격리를 검증합니다: `DNS_PROVIDER=digitalocean` 일 때 axios 클라이언트만 호출되고, `DNS_PROVIDER=route53` 일 때 Route53 클라이언트만 호출되며, 다른 provider 의 SDK 는 호출 0회임을 단언합니다.
+
+실제 AWS 에 대한 end-to-end 검증은 도메인 verify 완료 후 대시보드에서 테스트 메일을 발송하여 수행합니다.
+
+## 트러블슈팅
+
+**Q: "Invalid API key" 에러가 발생합니다**
+
+- ✅ 녹색 success 메시지에 표시된 **전체 API key** 를 복사했는지 확인하세요 (테이블의 마스킹된 버전 X)
+- ✅ API key 형식: `mrs_keyId_secretPart` (밑줄로 구분된 3 부분)
+
+**Q: `DNS_PROVIDER` 가 startup 시 throw 합니다**
+
+- ✅ 허용 값은 `digitalocean` 과 `route53` 입니다. 알 수 없는 값은 의도적으로 거부되어 오타가 silent 로 default 에 폴백되는 것을 방지합니다
+- ✅ 변수를 설정하지 않으면 `digitalocean` (default) 으로 동작합니다
+
+**Q: DigitalOcean DNS 자동화가 동작하지 않습니다**
+
+- ✅ DO API 토큰이 **Domains** 와 **Domain Records** 에 대해 **Read & Write** 권한을 가졌는지 확인하세요
+- ✅ 도메인이 DigitalOcean DNS 관리에 등록되어 있는지 확인하세요
+- ✅ 토큰 테스트: `curl -H "Authorization: Bearer YOUR_TOKEN" https://api.digitalocean.com/v2/domains`
+
+**Q: Route53 DNS 자동화가 동작하지 않습니다**
+
+- ✅ `AWS_HOSTED_ZONE_ID` 가 설정되어 있는지 확인하세요. 미설정 시 `verifyDomainOwnership` 는 `false` 를 반환하고 `setupDomainDNS` 는 throw 합니다
+- ✅ IAM user 가 `route53:GetHostedZone`, `route53:ListResourceRecordSets`, `route53:ChangeResourceRecordSets` 권한을 가져야 합니다
+- ✅ zone 테스트: `aws route53 get-hosted-zone --id YOUR_HOSTED_ZONE_ID`
+
+**Q: 도메인 verify 가 "pending" 에서 멈춰있습니다**
+
+- ✅ DNS propagation 은 보통 5-30분이 소요됩니다
+- ✅ 레코드 확인: `dig TXT _amazonses.yourdomain.com` / `dig CNAME tok1._domainkey.yourdomain.com`
+- ✅ 모든 DKIM CNAME (3개) 와 SES verify TXT 가 가시 상태인지 확인하세요
+
+**Q: AWS SES 권한 에러가 발생합니다**
+
+- ✅ IAM 정책에 위 SES 셋업 섹션의 SES **v2** 액션이 포함되어 있어야 합니다
+- ✅ 발송 region 에서 AWS 계정이 SES sandbox 모드를 벗어났는지 확인하세요
+
+**Q: Resend SDK 가 my-resend 와 동작하지 않습니다**
+
+- ✅ 호출 앱의 환경에서 `RESEND_BASE_URL="https://your-my-resend-domain.com/api"` 를 설정하세요
+- ✅ Resend API key 가 아닌 my-resend API key (`mrs_` 로 시작) 를 사용하세요
+
+## 프로덕션 배포
+
+본 프로젝트는 포함된 `Dockerfile` 로 컨테이너 친화적입니다. Node.js 장기 실행 프로세스를 지원하는 모든 플랫폼에서 동작합니다:
+
+- **컨테이너 PaaS**: Docker, Dokku, Coolify, Fly.io, Railway
+- **Kubernetes**: 샘플 매니페스트는 `k8s/` 하위에 있습니다 (stats 리포팅 cron job, deployment, ingress, HPA, namespace, services)
+- **관리형 Node.js 호스팅**: Vercel, Render, Netlify (서버리스 플랫폼에서는 webhook 엔드포인트가 추가 설정을 필요로 할 수 있음)
+
+핵심 프로덕션 요구사항:
+
+- 관리형 또는 self-hosted PostgreSQL 인스턴스
+- 발송 region 에서 SES sandbox 모드를 벗어난 AWS 계정
+- HTTPS 용 SSL 인증서
+- 환경변수 설정 (빠른 시작 섹션 참조)
+- `database.sql` 로 데이터베이스 스키마 초기화
+
+## 개발
+
+```bash
+# 의존성 설치
+npm install
+
+# 개발 서버 시작 (Turbopack)
+npm run dev
+
+# 프로덕션 빌드
+npm run build
+
+# 프로덕션 서버 시작
+npm start
+
+# Lint
+npm run lint
+
+# 테스트 (단위 + 통합)
+npm test
+```
+
+## 저장소 구조
+
+```
+my-resend/
+├── src/
+│   ├── app/                          # Next.js App Router
+│   │   ├── api/                      # API 라우트
+│   │   │   ├── auth/                 # 인증 엔드포인트
+│   │   │   ├── domains/              # 도메인 관리
+│   │   │   ├── api-keys/             # API key 관리
+│   │   │   ├── emails/               # 메일 발송 + 로그
+│   │   │   └── webhooks/             # SES webhook 핸들러
+│   │   ├── globals.css               # 전역 스타일
+│   │   ├── layout.tsx                # 루트 layout
+│   │   └── page.tsx                  # 메인 대시보드 페이지
+│   ├── components/                   # React 컴포넌트
+│   │   ├── Dashboard.tsx             # 메인 대시보드
+│   │   ├── LoginForm.tsx             # 인증
+│   │   └── *Tab.tsx                  # 탭 컴포넌트
+│   ├── contexts/                     # React 컨텍스트
+│   └── lib/                          # 핵심 비즈니스 로직
+│       ├── database.ts               # PostgreSQL 연결 풀 + 헬퍼
+│       ├── auth.ts                   # JWT 인증
+│       ├── ses.ts                    # AWS SES v2 wrapper
+│       ├── dns-provider.ts           # DNS provider 추상화 (DNS_PROVIDER 디스패치)
+│       ├── digitalocean.ts           # DigitalOcean DNS provider
+│       ├── route53.ts                # AWS Route53 DNS provider
+│       ├── domains.ts                # 도메인 관리 비즈니스 로직
+│       ├── api-keys.ts               # API key 로직
+│       ├── middleware.ts             # API 미들웨어 (auth helper)
+│       └── __tests__/                # Jest 단위 + 통합 테스트
+├── docs/
+│   └── plan/                         # 설계 / 변경 추적 문서
+├── k8s/                              # Kubernetes 매니페스트
+├── database.sql                      # PostgreSQL 스키마 (최초 배포 시 1회 적용)
+├── docker-compose.yml                # 로컬 개발 스택
+├── Dockerfile                        # 프로덕션 이미지
+├── jest.config.js                    # Jest 설정
+├── NOTICE                            # fork attribution + divergence 요약
+└── README.md                         # 영문 README
+```
+
+## 기여
+
+기여를 환영합니다.
+
+### 개발 셋업
+
+1. GitHub 에서 저장소를 fork 합니다
+2. fork 를 클론합니다: `git clone https://github.com/<your-username>/my-resend.git`
+3. 의존성을 설치합니다: `npm install`
+4. 빠른 시작 섹션을 따라 환경을 셋업합니다
+5. 테스트 스위트를 실행합니다: `npm test`
+6. 개발 서버를 시작합니다: `npm run dev`
+
+### 기여 가이드라인
+
+- 🐛 **버그 수정** — 회귀 테스트와 함께 항상 환영
+- ✨ **새 기능** — 먼저 issue 를 열어 논의하세요
+- 📝 **문서** — 개선은 항상 환영. 영문 README 가 source of truth 이며, 영문 변경 시 `README.ko.md` 를 동기화하여 parity 를 유지해주세요
+- 🧪 **테스트** — 새 기능에는 필수. 외부 SDK 는 mock 처리하고, CI 에서 라이브 AWS / DO 호출 금지
+- 💻 **코드 스타일** — 기존 패턴을 따르세요. ESLint 와 TypeScript strict mode 통과 필수
+
+### Pull Request 절차
+
+1. feature 브랜치 생성: `git checkout -b feat/short-description`
+2. 명확하고 서술적인 커밋으로 변경합니다
+3. 테스트를 추가하거나 갱신합니다
+4. 사용자 노출 동작이 변경됐다면 문서를 갱신합니다
+5. 변경 내용과 근거를 명확히 설명한 PR 을 제출합니다
+
+### 이슈 보고
+
+버그 보고 시 다음 정보를 포함해주세요:
+
+- 환경 (Node.js 버전, OS, 호스팅 플랫폼)
+- 재현 절차
+- 기대 동작 vs 실제 동작
+- 관련 에러 메시지 또는 로그
 
 ## 라이선스
 
-MIT — [LICENSE](./LICENSE) 참조. 원작자의 copyright 는 그대로 보존되며, my-resend 의 추가 기여분은 별도로 표시되어 있습니다.
+MIT — 전문은 [LICENSE](./LICENSE) 를 참조하세요. 원작자의 copyright 는 그대로 보존되며, my-resend 의 추가 기여분은 별도로 표시되어 있습니다.
 
-## 기여 / 문의
+## 지원
 
-이슈와 PR 은 GitHub 저장소에서 환영합니다: <https://github.com/Orchemi/my-resend>
+- 📖 **문서**: `docs/` 디렉토리 + 본 README
+- 🐛 **이슈**: [GitHub Issues](https://github.com/Orchemi/my-resend/issues) 로 버그 보고
+- 💡 **기능 제안**: 사용 사례를 포함하여 GitHub Issue 를 열어주세요
+
+## 로드맵
+
+- [ ] 메일 템플릿 지원
+- [ ] Webhook retry 메커니즘
+- [ ] 메일 분석 대시보드
+- [ ] 다중 사용자 지원
+- [ ] 메일 스케줄링
+- [ ] SMTP 서버 지원
+- [ ] 메일 캠페인 관리
+- [ ] Cloudflare DNS provider (`DNS_PROVIDER` 의 세 번째 옵션)
+- [ ] Route53 hosted-zone 자동 탐지 (`AWS_HOSTED_ZONE_ID` 환경변수 생략)

--- a/README.md
+++ b/README.md
@@ -4,42 +4,38 @@
 
 **A self-hosted, open-source mail gateway with a Resend-compatible API.**
 
-my-resend is a hard fork of [eibrahim/freeresend](https://github.com/eibrahim/freeresend) (MIT) — see [NOTICE](./NOTICE) for full attribution and the divergence point. It hosts your own email service using Amazon SES (with planned migration to SES v2) and supports DNS automation via DigitalOcean and AWS Route53. The API is compatible with the Resend SDK, so existing Resend users can migrate by setting `RESEND_BASE_URL` only.
-
-> ⚠️ **Status**: my-resend is in active divergence from upstream. Branding, SES v2 migration, and Route53 support are in progress. Until those land, the README below largely reflects upstream behavior.
-
-> 📰 **Original author's content**: The upstream project's author runs [**Frontend Weekly**](https://www.frontendweekly.co/) — credit to them for the original work this is based on.
+my-resend is a hard fork of [eibrahim/freeresend](https://github.com/eibrahim/freeresend) (MIT). See [NOTICE](./NOTICE) for full attribution and the divergence point. Emails are delivered through Amazon SES (via the v2 SDK), and DNS records can be managed automatically through DigitalOcean DNS or AWS Route53 — selectable at runtime via the `DNS_PROVIDER` environment variable. The HTTP API is compatible with the Resend Node.js SDK, so existing Resend users can migrate by setting `RESEND_BASE_URL` only.
 
 ## Features
 
-- 🚀 **100% Resend-compatible** - True drop-in replacement using environment variables
-- 🏠 **Self-hosted** - Full control over your email infrastructure
-- 📧 **Amazon SES integration** - Reliable email delivery with DKIM support
-- 🌐 **Automatic DNS setup** - Integration with Digital Ocean for DNS record creation
-- 🔐 **DKIM authentication** - Automatic DKIM key generation and DNS record creation
-- 🔑 **API key management** - Generate and manage multiple API keys per domain
-- 📊 **Email logging** - Track all sent emails with delivery status and logs
-- 🎯 **Domain verification** - Automated domain verification with SES
-- 🔒 **Secure** - JWT-based authentication and robust API key validation
-- 🐳 **Docker ready** - Containerized deployment with Docker Compose
-- 📝 **Comprehensive logging** - Detailed email logs with webhook support
+- 🚀 **100% Resend-compatible** — drop-in replacement using the `RESEND_BASE_URL` environment variable; no application code change
+- 🏠 **Self-hosted** — full control over your email infrastructure
+- 📧 **Amazon SES integration (v2 SDK)** — `SendEmailCommand`, identity management with combined verification + DKIM status
+- 🌐 **Pluggable DNS automation** — DigitalOcean or AWS Route53, selected by the `DNS_PROVIDER` env var. Adding a new provider takes one new module + one switch case
+- 🔐 **DKIM authentication** — automatic DKIM key generation and DNS record creation
+- 🔑 **API key management** — multiple `mrs_`-prefixed API keys per domain, bcrypt-hashed at rest
+- 📊 **Email logging** — every send tracked with delivery status and webhook events
+- 🎯 **Domain verification** — automated SES domain verification with idempotent retries
+- 🔒 **Secure** — JWT-based dashboard auth, bcrypt password hashing, parameterised SQL
+- 🐳 **Container-friendly** — Dockerfile included; runs on Docker, Dokku, Coolify, Fly.io, Kubernetes, or any host that runs a long-lived Node.js process
+- 🧪 **Tested** — Jest unit + integration suite covering the SES, DNS provider, and Route53 surfaces using `aws-sdk-client-mock` (no live AWS calls in CI)
 
 ## Quick Start
 
 ### Prerequisites
 
-- Node.js 18+
+- Node.js 20+
 - PostgreSQL database (local or hosted)
-- Amazon AWS account with SES access
-- Digital Ocean account (optional, for automatic DNS management)
+- An AWS account with SES access in your sending region
+- A DNS automation account on **either** DigitalOcean **or** AWS Route53 (optional — you can also create DNS records manually)
 
 ### Installation
 
 1. **Clone and install dependencies:**
 
 ```bash
-git clone <your-repo>
-cd freeresend
+git clone https://github.com/Orchemi/my-resend.git
+cd my-resend
 npm install
 ```
 
@@ -49,32 +45,42 @@ npm install
 cp .env.local.example .env.local
 ```
 
-Edit `.env.local` with your configuration:
+Edit `.env.local`:
 
 ```env
-# Next.js Configuration
+# Next.js
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=your-super-secret-jwt-key-here
 
-# Database Configuration (PostgreSQL)
+# Database (PostgreSQL)
 DATABASE_URL=postgresql://username:password@hostname:port/database
 
-# AWS SES Configuration
+# AWS SES
 AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=your-aws-access-key
 AWS_SECRET_ACCESS_KEY=your-aws-secret-key
 
-# Digital Ocean API Configuration (optional)
+# DNS provider selection (default: digitalocean)
+DNS_PROVIDER=digitalocean
+
+# DigitalOcean DNS (required when DNS_PROVIDER=digitalocean)
 DO_API_TOKEN=your-digitalocean-api-token
 
-# Application Configuration
+# AWS Route53 (required when DNS_PROVIDER=route53)
+# AWS_HOSTED_ZONE_ID=Z0123456789ABCDEFGHIJ
+
+# Admin
 ADMIN_EMAIL=admin@yourdomain.com
 ADMIN_PASSWORD=your-secure-admin-password
 ```
 
-3. **Set up the database:**
+3. **Initialise the database:**
 
-In your Supabase SQL editor, run the contents of `database.sql` to create all necessary tables.
+Apply the schema in `database.sql` against your PostgreSQL instance:
+
+```bash
+psql "$DATABASE_URL" -f database.sql
+```
 
 4. **Start the development server:**
 
@@ -87,13 +93,10 @@ Visit `http://localhost:3000` and log in with your admin credentials.
 ## AWS SES Setup
 
 1. **Verify your AWS account for SES:**
+   - Open the AWS SES console for your sending region
+   - Request production access if you need to send to unverified recipients
 
-   - Go to AWS SES console
-   - Move out of sandbox mode if needed
-
-- Configure sending limits
-
-2. **Create IAM user with SES permissions:**
+2. **Create an IAM user with SES v2 permissions:**
 
 ```json
 {
@@ -103,13 +106,11 @@ Visit `http://localhost:3000` and log in with your admin credentials.
       "Effect": "Allow",
       "Action": [
         "ses:SendEmail",
-        "ses:SendRawEmail",
-        "ses:VerifyDomainIdentity",
-        "ses:GetIdentityVerificationAttributes",
-        "ses:DeleteIdentity",
-        "ses:CreateConfigurationSet",
-        "ses:VerifyDomainDkim",
-        "ses:GetIdentityDkimAttributes"
+        "ses:CreateEmailIdentity",
+        "ses:GetEmailIdentity",
+        "ses:DeleteEmailIdentity",
+        "ses:PutEmailIdentityDkimAttributes",
+        "ses:CreateConfigurationSet"
       ],
       "Resource": "*"
     }
@@ -117,35 +118,70 @@ Visit `http://localhost:3000` and log in with your admin credentials.
 }
 ```
 
-> **Note**: The DKIM permissions (`ses:VerifyDomainDkim`, `ses:GetIdentityDkimAttributes`) are required for automatic DKIM setup.
+> **Note**: my-resend uses the SES v2 API (`@aws-sdk/client-sesv2`). The actions above are the v2 equivalents of the legacy `ses:VerifyDomainIdentity` / `ses:GetIdentityVerificationAttributes` / `ses:VerifyDomainDkim` / `ses:GetIdentityDkimAttributes` set.
 
-## Digital Ocean DNS Setup (Optional)
+## DNS Provider Setup
 
-If you want automatic DNS record creation:
+Pick whichever provider hosts your sending domain. The active provider is chosen by `DNS_PROVIDER`; default is `digitalocean` for backward compatibility with the upstream fork. Setting `DNS_PROVIDER` to an unknown value throws on startup so a typo can't silently fall back to the wrong provider.
 
-1. Create a Digital Ocean API token with read/write access
-2. Add your domains to Digital Ocean's DNS management
-3. Set the `DO_API_TOKEN` environment variable
+### Option A — DigitalOcean DNS
 
-## Using FreeResend with Resend SDK
+1. Create a DigitalOcean API token with **Read & Write** access to **Domains** and **Domain Records**
+2. Make sure each sending domain is listed under DigitalOcean DNS management
+3. Set environment variables:
+   ```env
+   DNS_PROVIDER=digitalocean
+   DO_API_TOKEN=your-digitalocean-api-token
+   ```
 
-FreeResend is **100% compatible** with the [Resend Node.js SDK](https://github.com/resend/resend-node)!
+### Option B — AWS Route53
 
-### Method 1: Environment Variable (Recommended)
+1. Create or pick an existing hosted zone for your sending domain
+2. Attach a Route53 statement to the same IAM user (or a separate one):
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Effect": "Allow",
+         "Action": [
+           "route53:GetHostedZone",
+           "route53:ListResourceRecordSets",
+           "route53:ChangeResourceRecordSets"
+         ],
+         "Resource": "arn:aws:route53:::hostedzone/Z0123456789ABCDEFGHIJ"
+       }
+     ]
+   }
+   ```
+3. Set environment variables:
+   ```env
+   DNS_PROVIDER=route53
+   AWS_HOSTED_ZONE_ID=Z0123456789ABCDEFGHIJ
+   # AWS_REGION / AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY are shared with SES
+   ```
+
+If neither provider is configured, my-resend will still generate the DNS records and display them in the dashboard for manual setup.
+
+## Using MyResend with the Resend SDK
+
+my-resend is **100% compatible** with the [Resend Node.js SDK](https://github.com/resend/resend-node).
+
+### Method 1: Environment Variable (recommended)
 
 Set the `RESEND_BASE_URL` environment variable:
 
 ```bash
-export RESEND_BASE_URL="https://your-freeresend-domain.com/api"
+export RESEND_BASE_URL="https://your-my-resend-domain.com/api"
 ```
 
-Then use Resend exactly as before:
+Then use the Resend SDK exactly as before:
 
 ```javascript
 import { Resend } from "resend";
 
-// No changes needed - FreeResend API key works with Resend SDK!
-const resend = new Resend("your-freeresend-api-key");
+// No code changes — your my-resend API key works with the Resend SDK
+const resend = new Resend("your-my-resend-api-key");
 
 const { data, error } = await resend.emails.send({
   from: "onboarding@yourdomain.com",
@@ -158,10 +194,10 @@ const { data, error } = await resend.emails.send({
 ### Method 2: Direct API
 
 ```javascript
-const response = await fetch("https://your-freeresend-domain.com/api/emails", {
+const response = await fetch("https://your-my-resend-domain.com/api/emails", {
   method: "POST",
   headers: {
-    Authorization: "Bearer your-freeresend-api-key",
+    Authorization: "Bearer your-my-resend-api-key",
     "Content-Type": "application/json",
   },
   body: JSON.stringify({
@@ -177,135 +213,115 @@ const response = await fetch("https://your-freeresend-domain.com/api/emails", {
 
 ### Authentication
 
-- `POST /api/auth/login` - Login with email/password
-- `GET /api/auth/me` - Get current user info
+- `POST /api/auth/login` — login with email/password
+- `GET /api/auth/me` — get current user info
 
 ### Domains
 
-- `GET /api/domains` - List all domains
-- `POST /api/domains` - Add new domain
-- `DELETE /api/domains/{id}` - Delete domain
-- `POST /api/domains/{id}/verify` - Check domain verification
+- `GET /api/domains` — list all domains
+- `POST /api/domains` — add a new domain (kicks off SES verify + DNS record creation via the active provider)
+- `DELETE /api/domains/{id}` — delete a domain
+- `POST /api/domains/{id}/verify` — re-check SES verification status
+- `POST /api/domains/{id}/retry-dns` — re-apply DNS records via the active provider
 
 ### API Keys
 
-- `GET /api/api-keys` - List API keys
-- `POST /api/api-keys` - Create new API key
-- `DELETE /api/api-keys/{id}` - Delete API key
+- `GET /api/api-keys` — list API keys
+- `POST /api/api-keys` — create a new API key
+- `DELETE /api/api-keys/{id}` — delete an API key
 
 ### Emails (Resend-compatible)
 
-- `POST /api/emails` - Send email
-- `GET /api/emails/logs` - Get email logs
-- `GET /api/emails/{id}` - Get specific email
+- `POST /api/emails` — send email
+- `GET /api/emails/logs` — list email logs
+- `GET /api/emails/{id}` — get a specific email
 
 ### Webhooks
 
-- `POST /api/webhooks/ses` - SES webhook endpoint
+- `POST /api/webhooks/ses` — SES webhook endpoint (delivery, bounce, complaint events)
 
 ## Domain Setup Process
 
-1. **Add domain** in the FreeResend dashboard
-2. **DNS Records** will be automatically created (if Digital Ocean is configured) or displayed for manual setup:
-
-   - **TXT record** - `_amazonses.yourdomain.com` for SES domain verification
-   - **MX record** - `yourdomain.com` for receiving emails via SES
-   - **SPF record** - `yourdomain.com` for sender policy framework
-   - **DMARC record** - `_dmarc.yourdomain.com` for email authentication policy
-   - **DKIM records** - 3 CNAME records for `*._domainkey.yourdomain.com` for email signing
-
-3. **Verify domain** - Click "Check Verification" once DNS records are live
-4. **Create API key** - Generate API keys for your verified domain
-5. **Start sending** - Use the API key with FreeResend or Resend SDK
+1. **Add a domain** in the my-resend dashboard
+2. **DNS records** are generated and either applied automatically (if a DNS provider is configured) or displayed for manual setup:
+   - **TXT record** — `_amazonses.yourdomain.com` for SES domain verification
+   - **MX record** — `yourdomain.com` for receiving emails via SES
+   - **SPF record** — `yourdomain.com` for sender policy framework
+   - **DMARC record** — `_dmarc.yourdomain.com` for email authentication policy
+   - **DKIM records** — three CNAME records under `*._domainkey.yourdomain.com` for email signing
+3. **Verify the domain** — click "Check Verification" once DNS records are live; SES verification is polled in the background as well
+4. **Create an API key** — generate keys for verified domains
+5. **Start sending** — use the API key with my-resend or the Resend SDK
 
 ## Testing Your Setup
 
-FreeResend includes test scripts to verify your installation:
-
-### Quick Test
+The project ships with a Jest suite. Tests are unit + integration level only — they do not hit live AWS / DigitalOcean endpoints (clients are mocked via `aws-sdk-client-mock` and `jest.mock("axios", ...)`).
 
 ```bash
-# Test with cURL (update variables in script first)
-./test-curl.sh
+npm test                    # run all tests
+npm run test:watch          # re-run on change
+npm run test:coverage       # coverage report
 ```
 
-### Comprehensive Test
+The integration suite under `src/lib/__tests__/domains-dns-integration.test.ts` verifies provider isolation: with `DNS_PROVIDER=digitalocean` only the axios client is exercised, with `DNS_PROVIDER=route53` only the Route53 client is. The other provider's SDK is asserted to receive zero calls.
 
-```bash
-# Test direct API + Resend SDK compatibility + Email logs
-node test-email.js
-```
-
-Both scripts will:
-
-- ✅ Send test emails using your API key
-- ✅ Verify Resend SDK compatibility
-- ✅ Check email logs functionality
-- 📧 Send actual emails to your inbox for verification
+For end-to-end verification against real AWS, send a test email from the dashboard once the domain is verified.
 
 ## Troubleshooting
-
-### Common Issues
 
 **Q: Getting "Invalid API key" errors**
 
 - ✅ Make sure you copied the **complete API key** from the green success message (not the masked version from the table)
-- ✅ API keys have format: `frs_keyId_secretPart` (3 parts separated by underscores)
+- ✅ API keys have format `mrs_keyId_secretPart` (three parts separated by underscores)
 
-**Q: Digital Ocean DNS automation not working**
+**Q: `DNS_PROVIDER` throws at startup**
+
+- ✅ Allowed values are `digitalocean` and `route53`. Unknown values are rejected on purpose so a typo can't silently fall back to the default
+- ✅ Leave the variable unset to use `digitalocean` (default)
+
+**Q: DigitalOcean DNS automation not working**
 
 - ✅ Verify your DO API token has **Read & Write** access to **Domains** and **Domain Records**
-- ✅ Ensure your domain is added to Digital Ocean's DNS management
-- ✅ Test token: `curl -H "Authorization: Bearer YOUR_TOKEN" https://api.digitalocean.com/v2/domains`
+- ✅ Ensure your domain is added to DigitalOcean's DNS management
+- ✅ Test the token: `curl -H "Authorization: Bearer YOUR_TOKEN" https://api.digitalocean.com/v2/domains`
+
+**Q: Route53 DNS automation not working**
+
+- ✅ Make sure `AWS_HOSTED_ZONE_ID` is set; `verifyDomainOwnership` returns `false` and `setupDomainDNS` throws when it is missing
+- ✅ The IAM user needs `route53:GetHostedZone`, `route53:ListResourceRecordSets`, and `route53:ChangeResourceRecordSets`
+- ✅ Test the zone: `aws route53 get-hosted-zone --id YOUR_HOSTED_ZONE_ID`
 
 **Q: Domain verification stuck at "pending"**
 
-- ✅ DNS propagation takes 5-30 minutes - be patient!
-- ✅ Check DNS records: `dig TXT _amazonses.yourdomain.com`
-- ✅ Ensure all DNS records are created properly
+- ✅ DNS propagation typically takes 5–30 minutes
+- ✅ Check the records: `dig TXT _amazonses.yourdomain.com` / `dig CNAME tok1._domainkey.yourdomain.com`
+- ✅ Make sure all DNKIM CNAMEs (3) plus the SES verification TXT are visible
 
 **Q: AWS SES permissions error**
 
-- ✅ Make sure your IAM policy includes **DKIM permissions**: `ses:VerifyDomainDkim` and `ses:GetIdentityDkimAttributes`
-- ✅ Verify your AWS account is out of SES sandbox mode
+- ✅ The IAM policy must include the SES **v2** actions listed in the SES setup section above
+- ✅ Verify your AWS account is out of SES sandbox mode for the sending region
 
-**Q: Resend SDK not working with FreeResend**
+**Q: Resend SDK not working with my-resend**
 
-- ✅ Set environment variable: `export RESEND_BASE_URL="https://your-domain.com/api"`
-- ✅ Use FreeResend API key (starts with `frs_`), not Resend API key
+- ✅ Set `RESEND_BASE_URL="https://your-my-resend-domain.com/api"` in the calling app's environment
+- ✅ Use a my-resend API key (starts with `mrs_`), not a Resend API key
 
 ## Production Deployment
 
-### Docker (Recommended)
+The project is container-friendly via the included `Dockerfile`. It runs on any platform that supports a long-lived Node.js process:
 
-```dockerfile
-FROM node:18-alpine
-WORKDIR /app
-COPY package*.json ./
-RUN npm ci --only=production
-COPY . .
-RUN npm run build
-EXPOSE 3000
-CMD ["npm", "start"]
-```
+- **Container PaaS**: Docker, Dokku, Coolify, Fly.io, Railway
+- **Kubernetes**: sample manifests live under `k8s/` (cron job for stats reporting, deployment, ingress, HPA, namespace, services)
+- **Managed Node.js hosting**: Vercel, Render, Netlify (note that webhook endpoints may need extra configuration on serverless platforms)
 
-### Environment Setup
+Key production requirements:
 
-- Use a production database (Supabase Pro or self-hosted PostgreSQL)
-- Set up proper SSL certificates
-- Configure firewall rules
-- Set up monitoring and logging
-- Configure SES with proper sending limits
-
-### Vercel Deployment
-
-FreeResend can be deployed on Vercel with some configuration:
-
-1. Connect your GitHub repo to Vercel
-2. Set environment variables in Vercel dashboard
-3. Deploy
-
-Note: Webhook endpoints might need special configuration for Vercel's serverless environment.
+- A managed or self-hosted PostgreSQL instance
+- AWS SES out of sandbox mode for the sending region
+- SSL certificates for HTTPS
+- Environment variables configured (see Quick Start)
+- Database schema initialised via `database.sql`
 
 ## Development
 
@@ -313,7 +329,7 @@ Note: Webhook endpoints might need special configuration for Vercel's serverless
 # Install dependencies
 npm install
 
-# Start development server
+# Start development server (Turbopack)
 npm run dev
 
 # Build for production
@@ -322,93 +338,102 @@ npm run build
 # Start production server
 npm start
 
-# Lint code
+# Lint
 npm run lint
+
+# Test (unit + integration)
+npm test
 ```
 
 ## Repository Structure
 
 ```
-freeresend/
+my-resend/
 ├── src/
-│   ├── app/                 # Next.js App Router
-│   │   ├── api/            # API routes
-│   │   │   ├── auth/       # Authentication endpoints
-│   │   │   ├── domains/    # Domain management
-│   │   │   ├── api-keys/   # API key management
-│   │   │   ├── emails/     # Email sending & logs
-│   │   │   └── webhooks/   # SES webhook handlers
-│   │   ├── globals.css     # Global styles
-│   │   ├── layout.tsx      # Root layout
-│   │   └── page.tsx        # Main dashboard page
-│   ├── components/         # React components
-│   │   ├── Dashboard.tsx   # Main dashboard
-│   │   ├── LoginForm.tsx   # Authentication
-│   │   └── *Tab.tsx        # Tab components
-│   ├── contexts/           # React contexts
-│   └── lib/                # Core business logic
-│       ├── supabase.ts     # Database client
-│       ├── auth.ts         # Authentication logic
-│       ├── ses.ts          # Amazon SES integration
-│       ├── digitalocean.ts # DNS automation
-│       ├── domains.ts      # Domain management
-│       ├── api-keys.ts     # API key logic
-│       └── middleware.ts   # API middleware
-├── database.sql            # Database schema
-├── docker-compose.yml      # Development setup
-├── test-email.js          # Comprehensive test script
-├── test-curl.sh           # Quick cURL test
-└── README.md              # This file
+│   ├── app/                          # Next.js App Router
+│   │   ├── api/                      # API routes
+│   │   │   ├── auth/                 # authentication endpoints
+│   │   │   ├── domains/              # domain management
+│   │   │   ├── api-keys/             # API key management
+│   │   │   ├── emails/               # email send + logs
+│   │   │   └── webhooks/             # SES webhook handlers
+│   │   ├── globals.css               # global styles
+│   │   ├── layout.tsx                # root layout
+│   │   └── page.tsx                  # main dashboard page
+│   ├── components/                   # React components
+│   │   ├── Dashboard.tsx             # main dashboard
+│   │   ├── LoginForm.tsx             # authentication
+│   │   └── *Tab.tsx                  # tab components
+│   ├── contexts/                     # React contexts
+│   └── lib/                          # core business logic
+│       ├── database.ts               # PostgreSQL connection pool + helpers
+│       ├── auth.ts                   # JWT authentication
+│       ├── ses.ts                    # AWS SES v2 wrapper
+│       ├── dns-provider.ts           # DNS provider abstraction (DNS_PROVIDER dispatch)
+│       ├── digitalocean.ts           # DigitalOcean DNS provider
+│       ├── route53.ts                # AWS Route53 DNS provider
+│       ├── domains.ts                # domain management business logic
+│       ├── api-keys.ts               # API key logic
+│       ├── middleware.ts             # API middleware (auth helpers)
+│       └── __tests__/                # Jest unit + integration tests
+├── docs/
+│   └── plan/                         # design / change-tracking documents
+├── k8s/                              # Kubernetes manifests
+├── database.sql                      # PostgreSQL schema (apply once on first deploy)
+├── docker-compose.yml                # local dev stack
+├── Dockerfile                        # production image
+├── jest.config.js                    # Jest configuration
+├── NOTICE                            # fork attribution + divergence summary
+└── README.md                         # this file
 ```
 
 ## Contributing
 
-We welcome contributions! Here's how to get started:
+Contributions are welcome.
 
 ### Development Setup
 
-1. **Fork the repository** on GitHub
-2. **Clone your fork**: `git clone https://github.com/eibrahim/freeresend.git`
-3. **Install dependencies**: `npm install`
-4. **Set up environment** following the Quick Start guide above
-5. **Run tests**: `node test-email.js`
-6. **Start development**: `npm run dev`
+1. Fork the repository on GitHub
+2. Clone your fork: `git clone https://github.com/<your-username>/my-resend.git`
+3. Install dependencies: `npm install`
+4. Set up environment following the Quick Start
+5. Run the test suite: `npm test`
+6. Start the dev server: `npm run dev`
 
 ### Contributing Guidelines
 
-- 🐛 **Bug fixes** - Always welcome with test cases
-- ✨ **New features** - Open an issue first to discuss
-- 📝 **Documentation** - Improvements always appreciated
-- 🧪 **Tests** - Required for new features
-- 💻 **Code style** - Follow existing patterns
+- 🐛 **Bug fixes** — always welcome with regression tests
+- ✨ **New features** — open an issue first to discuss
+- 📝 **Documentation** — improvements always appreciated; English README is the source of truth, please update `README.ko.md` to keep parity if you change English
+- 🧪 **Tests** — required for new features; mock external SDKs, never hit live AWS / DO from CI
+- 💻 **Code style** — follow existing patterns; ESLint and TypeScript strict mode must pass
 
 ### Pull Request Process
 
-1. Create a feature branch: `git checkout -b feature/your-feature-name`
+1. Create a feature branch: `git checkout -b feat/short-description`
 2. Make your changes with clear, descriptive commits
-3. Add tests for new functionality
-4. Update documentation if needed
-5. Submit a pull request with a clear description
+3. Add or update tests
+4. Update documentation if user-facing behaviour changed
+5. Submit a pull request with a clear description of the change and the rationale
 
 ### Reporting Issues
 
 When reporting bugs, please include:
 
-- Your environment (Node.js version, OS, etc.)
-- Steps to reproduce the issue
-- Expected vs actual behavior
+- Your environment (Node.js version, OS, hosting platform)
+- Steps to reproduce
+- Expected vs actual behaviour
 - Relevant error messages or logs
 
 ## License
 
-MIT License - see LICENSE file for details.
+MIT — see [LICENSE](./LICENSE) for the full text. The original author's copyright is preserved; my-resend's additions are listed alongside.
 
 ## Support
 
-- 📖 **Documentation**: Check SETUP.md for detailed setup instructions
-- 🐛 **Issues**: Report bugs via [GitHub Issues](https://github.com/eibrahim/freeresend/issues)
-- 💡 **Feature Requests**: Suggest improvements via GitHub Issues
-- 🚀 **Professional Support**: Custom development and enterprise support available via [EliteCoders](https://elitecoders.co/)
+- 📖 **Documentation**: `docs/` directory + this README
+- 🐛 **Issues**: report bugs via [GitHub Issues](https://github.com/Orchemi/my-resend/issues)
+- 💡 **Feature requests**: open a GitHub Issue with the use case
 
 ## Roadmap
 
@@ -419,29 +444,5 @@ MIT License - see LICENSE file for details.
 - [ ] Email scheduling
 - [ ] SMTP server support
 - [ ] Email campaign management
-
----
-
-## About the Author
-
-FreeResend is built and maintained by **[Emad Ibrahim](https://x.com/eibrahim)** - a software engineer and entrepreneur passionate about creating developer tools and open-source solutions.
-
-### 👨‍💻 **Connect with Emad**
-
-- 🐦 **Twitter**: [@eibrahim](https://x.com/eibrahim) - Follow for updates on FreeResend and web development insights
-- 📧 **Email**: [eibrahim@gmail.com](mailto:eibrahim@gmail.com)
-- 📰 **Newsletter**: [Frontend Weekly](https://www.frontendweekly.co/) - The best frontend development articles delivered weekly
-- 💼 **Professional Services**: Custom development and enterprise support via [EliteCoders](https://elitecoders.co/)
-
-### 🚀 **Need Custom Development?**
-
-If you need help with:
-
-- 🏗️ **Custom email infrastructure** modifications
-- 🚀 **Enterprise deployments** and scaling
-- 🔧 **Integration** with your existing systems
-- 🎯 **Feature development** beyond the roadmap
-
-**[Get in touch with EliteCoders →](https://elitecoders.co/)**
-
-_Building powerful software solutions for businesses worldwide_ 🌎
+- [ ] Cloudflare DNS provider (third option behind `DNS_PROVIDER`)
+- [ ] Hosted-zone auto-discovery for Route53 (skip the explicit `AWS_HOSTED_ZONE_ID` env)

--- a/docs/plan/003-followups-doc-and-refactor.md
+++ b/docs/plan/003-followups-doc-and-refactor.md
@@ -1,0 +1,176 @@
+# 003-followups-doc-and-refactor
+
+## 개요
+
+- **이슈**: [#6](https://github.com/Orchemi/my-resend/issues/6)
+- **브랜치**: `feat/6`
+- **상태**: 진행 중
+- **생성일**: 2026-04-26
+- **선행**: PR [#2](https://github.com/Orchemi/my-resend/pull/2) (SES v2), [#3](https://github.com/Orchemi/my-resend/pull/3) (KO README 1차), [#5](https://github.com/Orchemi/my-resend/pull/5) (Route53 + 추상화)
+
+이 문서는 SES v2 + Route53 트랙 이후 남아있던 6건의 follow-up 을 한 번에 처리하는 작업의 단일 진실(single source of truth) 이다.
+
+## 배경
+
+PR #2/#5 로 코드 측 마이그레이션은 마무리됐지만, 다음 흔적이 남아있다:
+
+1. **`NOTICE`** 가 *Planned Divergence* 끝줄에 "home-server (Dokku) with horbis infra conventions" 를 적어둔 상태 — 공개 OSS 의 NOTICE 에 특정 운영자의 인프라 의도를 새기는 것은 부적절.
+2. **`CLAUDE.md`** 가 여전히 upstream 인 FreeResend 를 기준으로 기술돼 있음. 스택 (SES SDK 버전, API key prefix, DB driver) 도 옛 정보. 이 파일은 LLM 코딩 어시스턴트가 본 레포에서 동작할 때의 1차 컨텍스트라 정확성이 중요.
+3. **`README.md`** (영문, ~450줄) 가 현재 my-resend 라는 자체 OSS 로 publish 됐음에도 불구하고 (a) FreeResend 브랜드, (b) freeresend 도메인, (c) frs_ API key prefix, (d) eibrahim/freeresend 기여 절차 URL, (e) "About the Author" 의 원작자 bio + Frontend Weekly newsletter 홍보, (f) EliteCoders 의 사내 컨설팅 영업 섹션을 그대로 두고 있음. fork attribution 은 NOTICE + 상단 한 줄로 충분하고, 위 항목들은 본 OSS 의 readme 에 들어갈 자리가 아님.
+4. **`README.ko.md`** 는 PR #3 직후에도 여전히 영문 README 의 1/9 분량의 한국어 요약. 다국어를 표방하는 이상 영문과 1:1 parity 가 일관성에 부합.
+5. **`DNSRecord` / `DnsProviderRecord`** 두 인터페이스가 `domains.ts` 와 `dns-provider.ts` 에 평행 정의되어 있음 (`ttl` optional vs required). 같은 데이터를 두 모양으로 쓰는 것은 후속에 혼선을 만든다.
+6. **`digitalocean.ts`** 가 모듈 로드 시점에 `process.env.DO_API_TOKEN` 을 capture 하고 axios client 도 즉시 생성. PR #5 작업 중 이 패턴이 테스트 setup (`jest.setup.env.js`) 을 강제로 도입하게 만들었음. 호출 시점 lazy 로 바꾸면 setup 파일이 사라질 수 있음.
+
+## 목표
+
+- [ ] `NOTICE` *Planned Divergence* 의 deployment-target 행 일반화 (또는 제거)
+- [ ] `CLAUDE.md` 전면 갱신 — FreeResend → MyResend, frs_ → mrs_, SES v1 → v2, Supabase 잔여 표현 제거, DNS provider 추상화 반영, Jest 테스트 워크플로우 명시
+- [ ] `README.md` 영문 전면 재작성 — 위 a)–f) 모두 제거, 현재 스택 (SES v2, Route53/DigitalOcean DNS_PROVIDER 추상화, Jest) 반영, 새 env (`DNS_PROVIDER`, `AWS_HOSTED_ZONE_ID`) 문서화, IAM policy 를 v2 액션으로 갱신
+- [ ] `README.ko.md` 영문 README 와 1:1 한국어 번역
+- [ ] 타입 통합: `domains.ts` 의 로컬 `DNSRecord` 제거, `dns-provider.ts` 의 `DnsProviderRecord` 단일 사용. `ttl` 은 required 로 정착 (모든 생산자가 이미 ttl 설정)
+- [ ] `digitalocean.ts` lazy env capture: `getApiToken()` / `getDoClient()` getter 도입. `jest.setup.env.js` 와 `jest.config.js` setupFiles 항목 제거 (가능하면)
+- [ ] `npm run lint && npm test && npm run build` 모두 통과
+- [ ] 6개 관심사로 분리 커밋 → `/pr auto` 가 그룹 분리 PR 생성
+
+## 설계
+
+### 접근 방식
+
+1. **OSS 가시성 0 누출**. 모든 산출물에서 `horbis`, `huns.site`, `home server`, `Dokku` 의 "내 환경" 컨텍스트, 특정 PaaS 편애 표현 금지. 테스트 fixture 도메인은 `example.com` 계열만.
+2. **fork attribution 은 NOTICE 가 단일 진실**. README 상단 1줄 + NOTICE 링크면 충분. 본문에서 원작자·원작자 회사·원작자 newsletter 등 별도 홍보 섹션은 모두 제거.
+3. **README EN 먼저 → KO 는 EN 의 정확한 1:1 번역**. EN 이 진실. 후속 EN 갱신마다 KO 동기화가 필요해지지만, 그것이 다국어 README 의 정상 운영 비용.
+4. **타입 통합 시 외부 시그니처 보존**. `DomainSetupResult.dnsRecords: DNSRecord[]` → `DnsProviderRecord[]`. `ttl?: number` → `ttl: number` 강화 — 모든 생산자가 이미 ttl 을 항상 set 하므로 안전.
+5. **lazy env capture 후 jest.setup.env.js 제거 가능 여부 평가**. 제거 시도 후 ses.ts (별도 module-load capture) 가 영향받는지 확인. ses.ts 의 SDK client 는 빈 credentials 도 throw 하지 않으므로 (실제 send() 호출에서만 fail) 문제 없을 것으로 예상.
+
+### 변경 범위
+
+```
+my-resend/
+├── NOTICE                                              # deployment-target 행 일반화
+├── CLAUDE.md                                           # 전면 갱신
+├── README.md                                           # 전면 재작성
+├── README.ko.md                                        # 영문과 1:1 번역
+├── jest.config.js                                      # setupFiles 제거 (가능하면)
+├── jest.setup.env.js                                   # 제거 (가능하면)
+├── src/lib/
+│   ├── digitalocean.ts                                 # getApiToken / getDoClient lazy 도입
+│   ├── dns-provider.ts                                 # DnsProviderRecord 단일 export 유지
+│   └── domains.ts                                      # 로컬 DNSRecord 제거 → DnsProviderRecord
+├── src/app/api/domains/[id]/retry-dns/route.ts         # DNSRecord 사용 시 import 변경
+└── docs/plan/
+    └── 003-followups-doc-and-refactor.md               # 본 문서
+```
+
+**무수정**:
+- `src/lib/ses.ts` (lazy 패턴 동일하게 적용 가능하지만 본 PR 범위 밖 — 별도 follow-up)
+- `src/lib/route53.ts`
+- 테스트 파일들 (lazy 변경이 외부 인터페이스를 깨지 않으므로 회귀만 확인)
+- 라이선스 (`LICENSE`) — 원작자 보존
+
+### 의사결정 기록
+
+| 결정 사항 | 선택지 | 결정 | 이유 |
+|-----------|--------|------|------|
+| `NOTICE` deployment-target 행 처리 | A) 행 자체 삭제 / B) 일반 표현으로 변경 | **A** | NOTICE 는 fork 의 attribution 과 divergence 항목만 담는 게 자연스러움. 배포 권장은 README 영역 |
+| README 의 fork attribution 위치 | A) 상단 1줄 + NOTICE 링크 / B) 본문에 expanded 섹션 | **A** | 사용자 (잠재적 contributor) 가 처음 보는 정보는 "이게 뭐고 / 어떻게 시작하는가". fork 의 expanded 컨텍스트는 NOTICE 에서 제공 |
+| 원작자 personal bio 보존 여부 | A) 보존 / B) 제거 (NOTICE 의 attribution 만 유지) | **B** | OSS fork 의 readme 에 원작자 personal contact / newsletter / 사내 컨설팅 홍보를 두는 것은 부적절. attribution 은 별개 |
+| EN/KO README parity 유지 비용 | A) KO 는 짧은 요약만 / B) 영문과 1:1 번역 | **B** | "다국어 README 가 있다" 는 문서 약속. 1:1 이 아니면 한국어 reader 가 영문 README 를 또 봐야 함 — 다국어의 의미 약화 |
+| `DNSRecord` vs `DnsProviderRecord` 통합 방향 | A) `DNSRecord` 유지 / B) `DnsProviderRecord` 단일 / C) 새 이름 | **B** | `dns-provider.ts` 가 unified API 출입구. 그 모듈이 export 하는 타입을 정식 이름으로 굳히는 것이 일관 |
+| `ttl` optional vs required | A) optional 유지 / B) required 강화 | **B** | 모든 생산자 (`generateDNSRecords`, provider 들) 가 이미 ttl 을 항상 set. optional 로 두면 unused tolerance 만 남음 |
+| `digitalocean.ts` lazy 적용 범위 | A) `DO_API_TOKEN` 만 / B) axios client 까지 / C) ses.ts 도 함께 | **B** | client 도 module-load 에 token 을 capture 하고 있어 token 만 lazy 로 바꿔도 client 헤더가 stale. 둘 다 lazy 가 정합. ses.ts 는 별도 PR |
+| `jest.setup.env.js` 제거 시점 | A) 본 PR 에서 제거 / B) 이후 PR 으로 이연 | **A** | lazy 변경의 직접적인 효과 검증 — 제거 후 모든 테스트가 통과하면 패턴이 옳다는 증거. 만약 회귀가 발생하면 본 PR 안에서 재도입하고 보고 |
+
+## 작업 단계
+
+### Phase 1: 작은 산문 정리 (NOTICE + CLAUDE.md)
+
+- [ ] `NOTICE` 의 *Planned Divergence* 마지막 행 제거
+- [ ] `CLAUDE.md` 전면 갱신
+  - 프로젝트 소개: FreeResend → MyResend
+  - Key Technologies: SES SDK v3 → SES v2 (`@aws-sdk/client-sesv2`), Digital Ocean API → DNS provider (DigitalOcean / Route53 via `DNS_PROVIDER`)
+  - DB: "migrated from Supabase" 잔여 표현 정리 (현재는 Supabase 트랙 자체가 본 fork 와 무관)
+  - API key prefix: `frs_` → `mrs_`
+  - env vars: `DNS_PROVIDER`, `AWS_HOSTED_ZONE_ID` 추가
+  - Testing Strategy: `node test-email.js`/`./test-curl.sh` (upstream 잔여) → `npm test` (Jest, 105 unit + integration)
+  - Domain Setup Workflow: DigitalOcean 단정 → DNS provider 추상화 반영
+- [ ] grep 으로 `FreeResend|frs_|freeresend` 0 건 확인 (의도된 attribution 컨텍스트 외)
+
+### Phase 2: README EN 전면 재작성
+
+- [ ] 상단: 한 줄 attribution + NOTICE 링크 (현재 줄 7 그대로 유지) + Status 배너 갱신 (SES v2 done, Route53 done)
+- [ ] "Original author's content" 줄 (Frontend Weekly 홍보) 제거
+- [ ] Features: DNS 자동화 표현을 "DigitalOcean / Route53 (configurable via `DNS_PROVIDER`)" 로
+- [ ] Quick Start: `cd freeresend` → `cd my-resend`. env 예시에 `DNS_PROVIDER`, `AWS_HOSTED_ZONE_ID` 추가. `In your Supabase SQL editor` → `Run database.sql against your PostgreSQL`
+- [ ] AWS SES IAM policy: SES v1 액션 → v2 액션 (`ses:CreateEmailIdentity`, `ses:GetEmailIdentity`, `ses:PutEmailIdentityDkimAttributes`, `ses:DeleteEmailIdentity`, `ses:SendEmail`, `ses:CreateConfigurationSet`)
+- [ ] DNS Provider Setup: 단일 DigitalOcean 섹션 → "Choose a DNS provider" 섹션 (DigitalOcean / Route53 양쪽 안내, IAM policy snippet 포함)
+- [ ] "Using FreeResend with Resend SDK" → "Using MyResend with the Resend SDK". 모든 예시의 `frs_` → `mrs_`, `your-freeresend-domain.com` → `your-my-resend-domain.com`
+- [ ] Domain Setup Process: "FreeResend dashboard" → "MyResend dashboard"
+- [ ] Testing Your Setup: `node test-email.js`/`./test-curl.sh` (upstream 스크립트 잔재) → `npm test`. 105 테스트 / aws-sdk-client-mock 언급
+- [ ] Troubleshooting: "FreeResend" → "MyResend", `frs_` → `mrs_`. 새 troubleshooting 항목: `DNS_PROVIDER` 잘못 지정 시 throw / `AWS_HOSTED_ZONE_ID` 미설정 시 verify false
+- [ ] Production Deployment: "Vercel" 단정 표현 완화 — "Docker (recommended for self-hosting)" + "Vercel/Netlify/Fly.io etc. for managed hosting" 같은 일반 나열
+- [ ] Repository Structure: `freeresend/` → `my-resend/`. `supabase.ts` 잔여 라인 제거 (실제 파일은 `database.ts`). `dns-provider.ts` / `route53.ts` 추가
+- [ ] Contributing: `git clone https://github.com/eibrahim/freeresend.git` → `git clone https://github.com/Orchemi/my-resend.git`
+- [ ] Reporting Issues: `eibrahim/freeresend/issues` → `Orchemi/my-resend/issues`
+- [ ] Roadmap: 현재 implemented 된 항목 (SES v2, Route53) 제거 또는 done 표시. 남은 backlog 만 유지
+- [ ] "About the Author" 섹션 전체 제거
+- [ ] "Need Custom Development?" / EliteCoders 영업 섹션 전체 제거
+- [ ] License: 그대로 유지 (단, "see LICENSE file" 만 — 별도 author 줄 추가 안 함)
+- [ ] grep 으로 `FreeResend|EliteCoders|eibrahim|Frontend Weekly|frs_|freeresend\.com|freeresend-domain` 0 건 확인
+
+### Phase 3: README KO 전체 번역
+
+- [ ] EN README 의 모든 섹션을 한국어로 번역
+- [ ] 코드 블록·env 변수명·URL 은 그대로 (영문 코드 위에 한글 주석/설명만 추가)
+- [ ] 마지막 검증: EN/KO 의 H2 섹션 개수·순서 동일
+
+### Phase 4: 타입 통합
+
+- [ ] `src/lib/domains.ts`:
+  - 로컬 `DNSRecord` interface 제거
+  - `import { DnsProviderRecord } from "./dns-provider"` 추가
+  - `DomainSetupResult.dnsRecords: DNSRecord[]` → `DnsProviderRecord[]`
+  - `DomainSetupResult.dnsProviderRecords?: DNSRecord[]` → `DnsProviderRecord[]`
+  - `safeParseDNSRecords` 시그니처 갱신
+- [ ] `src/app/api/domains/[id]/retry-dns/route.ts`:
+  - `DNSRecord` import 가 있으면 `DnsProviderRecord` 로
+- [ ] 다른 사용처 grep — 있으면 갱신
+- [ ] tsc 컴파일 검증 (build 단계에서 자동 확인)
+
+### Phase 5: lazy env capture
+
+- [ ] `src/lib/digitalocean.ts`:
+  - `const DO_API_TOKEN = process.env.DO_API_TOKEN` 제거 → `function getApiToken(): string | undefined { return process.env.DO_API_TOKEN; }`
+  - `const doClient = axios.create({...})` 제거 → `function getDoClient(): AxiosInstance { return axios.create({...}); }`
+  - 모든 `DO_API_TOKEN` 참조를 `getApiToken()` 으로
+  - 모든 `doClient` 참조를 `getDoClient()` 로
+  - 모듈 로드 시 console.warn 제거 (or 첫 사용 시점으로 이동)
+- [ ] `jest.setup.env.js` 제거
+- [ ] `jest.config.js` 의 `setupFiles: ["<rootDir>/jest.setup.env.js"]` 항목 제거
+- [ ] 전체 테스트 재실행 → 통과 확인. 회귀 발견 시 setupFiles 일부 보존 후 보고
+
+### Phase 6: 검증 + 커밋
+
+- [ ] `npm run lint` 통과
+- [ ] `npm test` 통과 (105 → ?)
+- [ ] `npm run build` 통과
+- [ ] 6 commits (관심사별):
+  1. `docs(notice): drop deployment-target opinion from Planned Divergence`
+  2. `docs(claude): align CLAUDE.md with current my-resend stack`
+  3. `refactor(types): unify DNSRecord and DnsProviderRecord`
+  4. `refactor(digitalocean): defer env capture to call sites`
+  5. `docs(readme): rewrite English README to drop upstream-specific branding`
+  6. `docs(readme): translate Korean README to full parity with English`
+- [ ] `/pr auto` — 자동 그룹핑 (예상: docs 4 commits 1 그룹 + refactor 2 commits 분리 또는 묶음)
+
+## 진행 로그
+
+| 날짜 | 내용 | 비고 |
+|------|------|------|
+| 2026-04-26 | 이슈 #6, `feat/6` 브랜치, 본 plan 작성 | PR #5 직후 6건 follow-up 묶음 |
+
+## 참고
+
+- 직전 plan 002: `docs/plan/002-route53-dns-provider.md`
+- AWS SESv2 IAM 액션 매핑: <https://docs.aws.amazon.com/sesv2/latest/APIReference/Welcome.html>
+- AWS Route53 IAM 액션: <https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/r53-api-permissions-ref.html>
+- 원본 upstream README (참고용): <https://github.com/eibrahim/freeresend/blob/main/README.md>


### PR DESCRIPTION
## 요약
- `README.md` 에서 upstream 특정 브랜딩 + 원작자 personal/commercial 섹션 제거 (FreeResend 표기, `frs_`, EliteCoders / Frontend Weekly / Emad Ibrahim, Supabase 잔재, Vercel 단정 표현).
- `README.ko.md` 전체 번역 → 두 언어 README 1:1 (각 16 H2 섹션).
- `CLAUDE.md` 를 현재 스택에 맞춤: SES v2 SDK, DigitalOcean + Route53 backend 의 DNS provider 추상화, `mrs_` API key, Jest + `aws-sdk-client-mock` 테스트 워크플로우.
- `NOTICE` *Planned Divergence* 의 특정 operator 호스팅 선택 문구 일반화 — fork attribution 은 유지하되 호스팅 주관은 제거.
- `docs/plan/003-followups-doc-and-refactor.md` 추가 — 본 작업 + 후속 코드 refactor 추적.

Part of #6.

## 상세
본 저장소는 public OSS 게이트웨이라 문서가 특정 호스트로 독자를 편향시키거나 upstream 원작자 personal 브랜딩을 담으면 안 됨. fork attribution 은 `NOTICE` (법적 필수) + 상단 한 줄 링크에 위치. 그 외 — 영업 홍보, newsletter 광고, 플랫폼 default 의견 — 은 모두 제거.

한국어 README 는 이전엔 부분 요약 (~50 줄) 이었고 영문은 ~450 줄. 각 파일 상단에 다국어 README 를 advertise 하는데 이런 격차는 한국어 reader 가 feature list 이후를 영문으로 또 봐야 하게 만듦. 이제 두 파일 모두 16 H2 섹션, 구조 정렬, 각 ~448 줄. 코드 블록·env 이름·URL 은 영문 유지, 산문만 번역. contributing 섹션이 향후 contributor 에게 두 파일 동기화를 명시적으로 요청.

`CLAUDE.md` 는 여전히 upstream FreeResend 프로젝트 (SES v3 SDK, Digital Ocean DNS 단일 경로, `frs_` API key, Supabase 마이그레이션 노트, `node test-email.js` / `./test-curl.sh` 테스트 스크립트 — 모두 미사용) 를 기술. 이제 실제 스택을 반영하고 향후 LLM 코딩 세션이 올바른 모듈을 가리키도록.

`NOTICE` 는 이전엔 한 operator 호스팅 타깃을 fork 의 \"default deployment target\" 으로 명시. NOTICE 는 upstream 으로부터 무엇이 분기됐는지 기술해야지 maintainer 가 어디서 운영하는지를 적으면 안 됨; 그 줄을 `DNS_PROVIDER` 선택 모델에 대한 중립 설명으로 교체.

## 변경 파일
```
docs/plan/
└── 003-followups-doc-and-refactor.md       # 신규 — 6개 follow-up 추적
NOTICE                                       # 배포 타깃 표현 중립화
CLAUDE.md                                    # 현재 스택 정렬 (SES v2, DNS 추상화, mrs_, Jest)
README.md                                    # 재작성 — upstream 특정 브랜딩 제거
README.ko.md                                 # 영문 1:1 번역
```

## 커밋
- [`d4f876b`](https://github.com/Orchemi/my-resend/commit/d4f876b) docs(plan): add 003 follow-ups plan
- [`8a9060a`](https://github.com/Orchemi/my-resend/commit/8a9060a) docs(notice): drop deployment-target opinion from Planned Divergence
- [`2315c3b`](https://github.com/Orchemi/my-resend/commit/2315c3b) docs(claude): align CLAUDE.md with current my-resend stack
- [`e0b3684`](https://github.com/Orchemi/my-resend/commit/e0b3684) docs(readme): rewrite English README to drop upstream-specific branding
- [`d40671c`](https://github.com/Orchemi/my-resend/commit/d40671c) docs(readme): translate Korean README to full parity with English

## 테스트 계획
- [x] 문서에 대해 `grep -iE \"FreeResend|EliteCoders|Frontend Weekly|frs_|emad ibrahim|huns\.site|horbis\"` 가 NOTICE / CLAUDE.md / README 헤더의 합법 fork-attribution 매치만 반환
- [x] EN/KO README H2 섹션 개수 일치 (각 16) 및 섹션 순서 동일
- [x] docs-only 변경이라 기존 테스트 suite 영향 없음 (별도 refactor PR 후속)