### PR TITLE
코드 리팩토링: DnsProviderRecord 타입 통합 + DigitalOcean env capture lazy 화

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,11 +7,6 @@ const createJestConfig = nextJest({
 
 // Add any custom config to be passed to Jest
 const customJestConfig = {
-  // Run before each test file's module graph loads. Seeds env vars that
-  // source modules (e.g. src/lib/digitalocean.ts) capture at
-  // module-load time, so jest.mock + import order doesn't have to fight
-  // process.env timing.
-  setupFiles: ['<rootDir>/jest.setup.env.js'],
   setupFilesAfterEnv: [],
   testEnvironment: 'jsdom',
   collectCoverageFrom: [

--- a/jest.setup.env.js
+++ b/jest.setup.env.js
@@ -1,5 +1,0 @@
-// Seed env vars that some src/lib/*.ts modules read at module-load time
-// (before any test code can run). Test cases may still override these
-// via process.env mutations + module re-import patterns where needed.
-process.env.DO_API_TOKEN = process.env.DO_API_TOKEN || "test-do-token";
-process.env.AWS_REGION = process.env.AWS_REGION || "us-east-1";

--- a/src/lib/digitalocean.ts
+++ b/src/lib/digitalocean.ts
@@ -1,22 +1,33 @@
-import axios from "axios";
+import axios, { type AxiosInstance } from "axios";
 
 const DO_API_BASE = "https://api.digitalocean.com/v2";
-const DO_API_TOKEN = process.env.DO_API_TOKEN;
 
-if (!DO_API_TOKEN) {
-  console.warn(
-    "DO_API_TOKEN not set. Digital Ocean DNS management will be disabled."
-  );
+/**
+ * Read the DigitalOcean API token at call time rather than module-load
+ * time. Module-load capture made tests fragile (env had to be seeded
+ * before any import that transitively pulled this module) and prevented
+ * the token from being rotated in long-running processes.
+ */
+function getApiToken(): string | undefined {
+  return process.env.DO_API_TOKEN;
 }
 
-const doClient = axios.create({
-  baseURL: DO_API_BASE,
-  headers: {
-    Authorization: `Bearer ${DO_API_TOKEN}`,
-    "Content-Type": "application/json",
-  },
-  timeout: 10000, // 10 second timeout
-});
+/**
+ * Build a fresh axios client per call so the `Authorization` header
+ * always reflects the current `DO_API_TOKEN`. `axios.create` is cheap
+ * (a config + interceptor wrapper, no network), so the per-call cost
+ * is negligible relative to the HTTP request itself.
+ */
+function getDoClient(): AxiosInstance {
+  return axios.create({
+    baseURL: DO_API_BASE,
+    headers: {
+      Authorization: `Bearer ${getApiToken()}`,
+      "Content-Type": "application/json",
+    },
+    timeout: 10000, // 10 second timeout
+  });
+}
 
 // Helper function to add retry logic with exponential backoff
 async function retryRequest<T>(
@@ -85,13 +96,13 @@ export interface DODomain {
 }
 
 export async function getDomains(): Promise<DODomain[]> {
-  if (!DO_API_TOKEN) {
+  if (!getApiToken()) {
     throw new Error("Digital Ocean API token not configured");
   }
 
   try {
     const response = await retryRequest(async () => {
-      return await doClient.get("/domains");
+      return await getDoClient().get("/domains");
     });
     return response.data.domains;
   } catch (error: unknown) {
@@ -110,13 +121,13 @@ export async function getDomains(): Promise<DODomain[]> {
 export async function getDomainRecords(
   domain: string
 ): Promise<DODomainRecord[]> {
-  if (!DO_API_TOKEN) {
+  if (!getApiToken()) {
     throw new Error("Digital Ocean API token not configured");
   }
 
   try {
     const response = await retryRequest(async () => {
-      return await doClient.get(`/domains/${domain}/records`);
+      return await getDoClient().get(`/domains/${domain}/records`);
     });
     return response.data.domain_records;
   } catch (error: unknown) {
@@ -136,7 +147,7 @@ export async function createDNSRecord(
   domain: string,
   record: DNSRecord
 ): Promise<DODomainRecord> {
-  if (!DO_API_TOKEN) {
+  if (!getApiToken()) {
     throw new Error("Digital Ocean API token not configured");
   }
 
@@ -172,7 +183,7 @@ export async function createDNSRecord(
     }
 
     const response = await retryRequest(async () => {
-      return await doClient.post(`/domains/${domain}/records`, payload);
+      return await getDoClient().post(`/domains/${domain}/records`, payload);
     });
     return response.data.domain_record;
   } catch (error: unknown) {
@@ -193,7 +204,7 @@ export async function updateDNSRecord(
   recordId: number,
   record: Partial<DNSRecord>
 ): Promise<DODomainRecord> {
-  if (!DO_API_TOKEN) {
+  if (!getApiToken()) {
     throw new Error("Digital Ocean API token not configured");
   }
 
@@ -208,7 +219,7 @@ export async function updateDNSRecord(
     if (record.ttl) payload.ttl = record.ttl;
     if (record.type) payload.type = record.type;
 
-    const response = await doClient.put(
+    const response = await getDoClient().put(
       `/domains/${domain}/records/${recordId}`,
       payload
     );
@@ -230,12 +241,12 @@ export async function deleteDNSRecord(
   domain: string,
   recordId: number
 ): Promise<void> {
-  if (!DO_API_TOKEN) {
+  if (!getApiToken()) {
     throw new Error("Digital Ocean API token not configured");
   }
 
   try {
-    await doClient.delete(`/domains/${domain}/records/${recordId}`);
+    await getDoClient().delete(`/domains/${domain}/records/${recordId}`);
   } catch (error: unknown) {
     const axiosError = error as {
       response?: { data?: { message?: string } };
@@ -253,7 +264,7 @@ export async function setupDomainDNS(
   domain: string,
   dnsRecords: DNSRecord[]
 ): Promise<DODomainRecord[]> {
-  if (!DO_API_TOKEN) {
+  if (!getApiToken()) {
     console.warn(
       "Digital Ocean API not configured. DNS records need to be created manually."
     );
@@ -352,7 +363,7 @@ export async function setupDomainDNS(
 }
 
 export async function verifyDomainOwnership(domain: string): Promise<boolean> {
-  if (!DO_API_TOKEN) {
+  if (!getApiToken()) {
     return false;
   }
 

--- a/src/lib/domains.ts
+++ b/src/lib/domains.ts
@@ -7,31 +7,28 @@ import {
   enableDomainDkim,
   getDomainDkimTokens,
 } from "./ses";
-import { setupDomainDNS, verifyDomainOwnership } from "./dns-provider";
+import {
+  setupDomainDNS,
+  verifyDomainOwnership,
+  type DnsProviderRecord,
+} from "./dns-provider";
 import type { Domain } from "./database";
-
-export interface DNSRecord {
-  type: string;
-  name: string;
-  value: string;
-  ttl?: number;
-}
 
 export interface DomainSetupResult {
   domain: Domain;
-  dnsRecords: DNSRecord[];
+  dnsRecords: DnsProviderRecord[];
   sesConfigurationSet?: string;
   /**
    * Records that the active DNS provider actually created or updated as
    * part of this setup call. Provider-specific shapes are normalized in
    * `dns-provider.ts` before reaching this layer.
    */
-  dnsProviderRecords?: DNSRecord[];
+  dnsProviderRecords?: DnsProviderRecord[];
   setupInstructions: string;
 }
 
 // Helper function to safely parse DNS records (handles both string and object)
-function safeParseDNSRecords(dnsRecords: unknown): DNSRecord[] {
+function safeParseDNSRecords(dnsRecords: unknown): DnsProviderRecord[] {
   if (!dnsRecords) return [];
   if (typeof dnsRecords === "string") {
     try {
@@ -115,7 +112,7 @@ export async function addDomain(
     );
 
     // 5. Setup DNS records via the configured DNS provider (if any)
-    let dnsProviderRecords: DNSRecord[] = [];
+    let dnsProviderRecords: DnsProviderRecord[] = [];
     let setupInstructions = "";
 
     try {
@@ -183,7 +180,7 @@ async function verifyAndCompleteExistingDomain(
   let needsUpdate = false;
   const updateFields: Record<string, string> = {};
   let setupInstructions = "";
-  let dnsProviderRecords: DNSRecord[] = [];
+  let dnsProviderRecords: DnsProviderRecord[] = [];
 
   try {
     // 1. Check SES domain status


### PR DESCRIPTION
## 요약
- `domains.ts` 의 로컬 `DNSRecord` interface 제거 → `DomainSetupResult` 가 `DnsProviderRecord` (`dns-provider.ts` 에서 export) 직접 사용. 이제 `ttl` 은 어디서나 required.
- `digitalocean.ts` 의 module-load `DO_API_TOKEN` + `doClient` 캡처를 호출-시점 `getApiToken()` / `getDoClient()` 로 교체.
- env 캡처가 deferred 되면서 `jest.setup.env.js` 와 그에 매칭되는 `setupFiles` 항목 제거 — module-load 전 `DO_API_TOKEN` 시드가 더 이상 필요 없음.

Part of #6.

## 상세

### 타입 통합

`domains.ts` 가 이전엔 자체 `DNSRecord { type, name, value, ttl?: number }` 를 `dns-provider.ts` 의 `DnsProviderRecord { type, name, value, ttl: number }` 와 평행 선언. 두 이름이 같은 호출 경로에 동시 등장했고 optional `ttl` 은 unused tolerance — 모든 생산자 (`ses.generateDNSRecords`, 두 DNS provider) 가 이미 `ttl: 300` 설정. 로컬 선언 제거, `DnsProviderRecord` import, `ttl` 을 required 로 강화. 105-test lib suite 그대로 통과.

`digitalocean.ts` 는 여전히 자체 internal `DNSRecord` 를 `description?` 옵션 필드와 함께 정의 — module-internal input shape 로 의도적 보존. external type-import 0건이라 consumer 영향 없이 별도 정리 가능; 본 PR 범위 밖.

### Lazy env capture

`digitalocean.ts` 가 module-load 시점에 `process.env.DO_API_TOKEN` 읽고 axios client 도 같이 만들어, 테스트가 어떤 import 보다도 먼저 env 를 seed (`jest.setup.env.js`) 해야 했음. 호출-시점 `getApiToken()` / `getDoClient()` 가 두 문제 모두 해결:

- 테스트가 `process.env.DO_API_TOKEN` 을 모듈 re-import 없이 case 간 변경 가능
- 토큰 rotation 안전 — 매 request 가 현재 env 값을 읽음
- per-call `axios.create` 비용 무시 가능 (config wrapper + interceptor manager 만, network 작업 없음)

`jest.setup.env.js` 완전 제거. `ses.ts` 는 같은 module-load 패턴이지만 테스트가 SDK 를 `.send()` 에서 가로채므로 `AWS_REGION` 시드 제거도 안전 — PR 단위 명확화 위해 별도 follow-up 으로 분리.

## 변경 파일
```
src/lib/
├── domains.ts                # 로컬 DNSRecord 제거, DnsProviderRecord 사용
└── digitalocean.ts           # getApiToken() / getDoClient() lazy
jest.config.js                 # setupFiles 항목 제거
jest.setup.env.js              # 삭제
```

## 커밋
- [`8da2c9c`](https://github.com/Orchemi/my-resend/commit/8da2c9c) refactor(types): unify DNSRecord and DnsProviderRecord
- [`d1f3870`](https://github.com/Orchemi/my-resend/commit/d1f3870) refactor(digitalocean): defer env capture to call sites

## 테스트 계획
- [x] `npm run lint` — warning/error 0
- [x] `npm test -- --testPathPatterns='src/lib'` — 7 suites / 105 tests 통과 (ses, dns-provider, route53, integration suite 회귀 0)
- [x] `npm run build` — production build OK (typecheck strict, 모든 라우트 컴파일)
- [x] `jest.setup.env.js` 제거 — lib suite 가 env 시드 없이도 그대로 통과

## 본 PR 범위 밖 (별도 PR)
- `ses.ts` 에 동일 lazy env 패턴 적용
- `digitalocean.ts` 내부 `DNSRecord` (with `description?`) 를 `DnsProviderRecord` 로 통합