### PR TITLE
SES env capture 를 호출 시점으로 미루기

### DIFF
--- a/docs/plan/004-ses-lazy-env-capture.md
+++ b/docs/plan/004-ses-lazy-env-capture.md
@@ -1,0 +1,105 @@
+# 004-ses-lazy-env-capture
+
+## 개요
+
+- **이슈**: [#9](https://github.com/Orchemi/my-resend/issues/9)
+- **브랜치**: `feat/9`
+- **상태**: 진행 중
+- **생성일**: 2026-04-26
+- **선행**: [PR #8](https://github.com/Orchemi/my-resend/pull/8) — `digitalocean.ts` 에 동일 패턴 적용 완료
+
+본 작업은 직전 PR #8 의 `digitalocean.ts` lazy env capture 와 정확히 동일한 패턴을 `src/lib/ses.ts` 에 적용한다.
+
+## 배경
+
+`src/lib/ses.ts` 가 module-load 시점에 `SESv2Client` 인스턴스를 만들면서 `process.env.AWS_REGION` / `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` 를 캡처한다:
+
+```typescript
+const sesClient = new SESv2Client({
+  region: process.env.AWS_REGION || "us-east-1",
+  credentials: {
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+  },
+});
+```
+
+PR #8 이후 `digitalocean.ts` 는 `getApiToken()` / `getDoClient()` 호출-시점 패턴이고, ses.ts 만 module-load 캡처가 남아있다. 두 모듈의 동작 비대칭은 향후 새 모듈을 추가할 때 어느 쪽 패턴을 따라야 하는지 모호하게 만든다.
+
+## 목표
+
+- [ ] `src/lib/ses.ts` 의 module-level `sesClient` 제거 → `getSesClient()` 함수 도입
+- [ ] 11 개 call site (`sesClient.send(...)` → `getSesClient().send(...)`) 갱신
+- [ ] 기존 32 ses 단위 테스트 + 통합 테스트 무회귀 확인 (`mockClient(SESv2Client)` 가 prototype 레벨 패치라 매 호출마다 새 instance 도 mock 처리됨)
+- [ ] `npm run lint && npm test && npm run build` 모두 통과
+
+## 설계
+
+### 접근 방식
+
+`digitalocean.ts` 와 정확히 동일한 패턴:
+
+```typescript
+function getSesClient(): SESv2Client {
+  return new SESv2Client({
+    region: process.env.AWS_REGION || "us-east-1",
+    credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+    },
+  });
+}
+```
+
+매 호출마다 새 `SESv2Client` 인스턴스를 만든다. SDK client 생성 비용은 config wrapper + middleware stack 구성뿐이라 무시 가능 — 실제 SDK 호출 (HTTP request) 비용에 비하면 사실상 0.
+
+### 변경 범위
+
+```
+my-resend/
+└── src/lib/
+    └── ses.ts                    # module-level sesClient → getSesClient() 함수
+```
+
+**무수정**:
+- `src/lib/__tests__/ses.test.ts` — `mockClient(SESv2Client)` 패턴이 prototype 패치라 인스턴스 변경에 robust
+- 다른 lib 모듈, API 라우트 — `ses.ts` 의 export 시그니처 무변경
+
+### 의사결정 기록
+
+| 결정 사항 | 선택지 | 결정 | 이유 |
+|-----------|--------|------|------|
+| Memoization 여부 | A) 매 호출 새 instance / B) module-let 변수에 첫 호출 시점 cache | **A** | digitalocean.ts 와 동일 패턴 유지. credential rotation 안전성 + 성능 차이 무시 가능 |
+| getter 이름 | A) `getSesClient()` / B) `createSesClient()` | **A** | digitalocean 의 `getDoClient()` 와 명명 일관 (`get` 접두사) |
+| 적용 범위 | A) ses.ts 만 / B) ses.ts + dns-provider.ts 도 함께 | **A** | dns-provider.ts 는 import 만 할 뿐 SDK client 를 직접 만들지 않음. 본 PR scope 명확화 |
+
+## 작업 단계
+
+### Phase 1: refactor
+
+- [ ] `src/lib/ses.ts` 상단 `const sesClient = new SESv2Client(...)` 제거
+- [ ] `function getSesClient(): SESv2Client { ... }` 추가
+- [ ] 11 개 `sesClient.send(...)` → `getSesClient().send(...)`
+
+### Phase 2: 검증
+
+- [ ] `npm run lint` 통과
+- [ ] `npm test --testPathPatterns='src/lib'` 통과 (105 → 105)
+- [ ] `npm run build` 통과
+
+### Phase 3: 커밋 + PR
+
+- [ ] 영어 conventional 커밋 (1 commit, 단일 concern)
+- [ ] `gh pr create` → develop 머지
+
+## 진행 로그
+
+| 날짜 | 내용 | 비고 |
+|------|------|------|
+| 2026-04-26 | 이슈 #9, `feat/9` 브랜치, 본 plan 작성 | PR #8 직후 대칭 정합 작업 |
+
+## 참고
+
+- 직전 plan 003: `docs/plan/003-followups-doc-and-refactor.md` (의사결정 §"ses.ts 는 별도 PR" 정합)
+- 동일 패턴 적용 PR: <https://github.com/Orchemi/my-resend/pull/8>
+- AWS SES v2 SDK: <https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sesv2/>

--- a/src/lib/ses.ts
+++ b/src/lib/ses.ts
@@ -9,13 +9,25 @@ import {
   PutEmailIdentityDkimAttributesCommand,
 } from "@aws-sdk/client-sesv2";
 
-const sesClient = new SESv2Client({
-  region: process.env.AWS_REGION || "us-east-1",
-  credentials: {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
-  },
-});
+/**
+ * Build a fresh SESv2 client per call. Mirrors the lazy pattern used in
+ * `digitalocean.ts` (PR #8): credentials and region are read from
+ * `process.env` at call time so credential rotation is safe and tests
+ * can mutate AWS env between cases without re-importing the module.
+ *
+ * `SESv2Client` construction is config + middleware wiring only — no
+ * network work — so per-call instantiation is negligible compared to
+ * the actual `.send()` call that follows.
+ */
+function getSesClient(): SESv2Client {
+  return new SESv2Client({
+    region: process.env.AWS_REGION || "us-east-1",
+    credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+    },
+  });
+}
 
 export interface EmailAttachment {
   filename: string;
@@ -114,7 +126,7 @@ export async function sendEmail(options: SendEmailOptions): Promise<string> {
       : undefined,
   });
 
-  const response = await sesClient.send(command);
+  const response = await getSesClient().send(command);
   return response.MessageId!;
 }
 
@@ -189,7 +201,7 @@ export async function sendRawEmail(options: SendEmailOptions): Promise<string> {
     },
   });
 
-  const response = await sesClient.send(command);
+  const response = await getSesClient().send(command);
   return response.MessageId!;
 }
 
@@ -201,7 +213,7 @@ export async function verifyDomain(
   // back DkimAttributes.Tokens[0] which doubles as the SES verification
   // token used in the `_amazonses.<domain>` TXT record.
   try {
-    await sesClient.send(
+    await getSesClient().send(
       new CreateEmailIdentityCommand({ EmailIdentity: domain })
     );
   } catch (error: unknown) {
@@ -212,7 +224,7 @@ export async function verifyDomain(
     // identity already present — fall through to GetEmailIdentity
   }
 
-  const get = await sesClient.send(
+  const get = await getSesClient().send(
     new GetEmailIdentityCommand({ EmailIdentity: domain })
   );
 
@@ -227,21 +239,21 @@ export async function verifyDomain(
 export async function getDomainVerificationStatus(
   domain: string
 ): Promise<string> {
-  const response = await sesClient.send(
+  const response = await getSesClient().send(
     new GetEmailIdentityCommand({ EmailIdentity: domain })
   );
   return mapVerificationStatus(response.VerificationStatus);
 }
 
 export async function enableDomainDkim(domain: string): Promise<string[]> {
-  await sesClient.send(
+  await getSesClient().send(
     new PutEmailIdentityDkimAttributesCommand({
       EmailIdentity: domain,
       SigningEnabled: true,
     })
   );
 
-  const get = await sesClient.send(
+  const get = await getSesClient().send(
     new GetEmailIdentityCommand({ EmailIdentity: domain })
   );
 
@@ -249,14 +261,14 @@ export async function enableDomainDkim(domain: string): Promise<string[]> {
 }
 
 export async function getDomainDkimTokens(domain: string): Promise<string[]> {
-  const response = await sesClient.send(
+  const response = await getSesClient().send(
     new GetEmailIdentityCommand({ EmailIdentity: domain })
   );
   return response.DkimAttributes?.Tokens || [];
 }
 
 export async function deleteDomainIdentity(domain: string): Promise<void> {
-  await sesClient.send(
+  await getSesClient().send(
     new DeleteEmailIdentityCommand({ EmailIdentity: domain })
   );
 }
@@ -269,7 +281,7 @@ export async function createConfigurationSet(domain: string): Promise<string> {
       ConfigurationSetName: configSetName,
     });
 
-    await sesClient.send(command);
+    await getSesClient().send(command);
 
     return configSetName;
   } catch (error: unknown) {


### PR DESCRIPTION
## 요약
- `src/lib/ses.ts` 의 module-load `SESv2Client` 생성을 호출-시점 `getSesClient()` 헬퍼로 교체.
- PR #8 에서 `digitalocean.ts` 에 적용된 lazy env-capture 패턴 그대로 — 이제 DNS / SES 두 모듈이 env read 측면에서 동일 동작.

Closes #9.

## 상세

`ses.ts` 가 이전엔 module-load 시점에 단일 `SESv2Client` 를 생성하면서 `AWS_REGION` / `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` 를 `process.env` 에서 첫 import 시점에 캡처. PR #8 이 `digitalocean.ts` 를 lazy 로 만든 뒤 두 모듈이 misuse 하기 쉬운 방식으로 분기 — 새 SDK-backed 모듈 추가 시 두 패턴 중 임의 선택.

per-call `SESv2Client` 인스턴스화는 config + middleware-stack 와이어링만 (network 작업 없음) 이므로 실제 `.send()` 호출 대비 비용 무시 가능. 테스트 영향 없음: `mockClient(SESv2Client)` 가 prototype 레벨에서 패치하므로 매 fresh 인스턴스도 가로챔.

## 변경 파일
```
docs/plan/
└── 004-ses-lazy-env-capture.md       # 신규 — 정합성 기록 작은 plan
src/lib/
└── ses.ts                            # module-level sesClient → getSesClient() 함수
```

## 커밋
- [`b65271e`](https://github.com/Orchemi/my-resend/commit/b65271e) docs(plan): add 004 ses lazy env capture plan
- [`b769f32`](https://github.com/Orchemi/my-resend/commit/b769f32) refactor(ses): defer env capture to call sites

## 테스트 계획
- [x] `npm run lint` — warning/error 0
- [x] `npm test -- --testPathPatterns='src/lib'` — 7 suites / 105 tests 통과 (32 ses + 10 dns-provider + 10 route53 + 2 integration + 27 notifications + 9 database-waitlist + 15 pricing-calculator). 회귀 0.
- [x] `npm run build` — production build OK; typecheck strict, 모든 라우트 컴파일.

## 본 PR 범위 밖
- Cloudflare DNS provider (별도 roadmap)
- `digitalocean.ts` 내부 `DNSRecord` (with optional `description?`) → `DnsProviderRecord` 통합 (별도 작은 cleanup PR)