### PR TITLE
sending domain 으로 Route53 hosted zone 자동 탐지

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ The schema lives in `database.sql`; there is no migration framework — apply on
 - v3 SDK (`@aws-sdk/client-route-53`)
 - Idempotent UPSERT via a single `ChangeResourceRecordSetsCommand` batch — lists existing records first and skips no-op rows
 - Preserves CNAME trailing dots and quotes TXT values per RFC 1035
-- Requires `AWS_HOSTED_ZONE_ID`; without it `verifyDomainOwnership` returns `false` and `setupDomainDNS` throws
+- `AWS_HOSTED_ZONE_ID` is optional — if unset, `resolveHostedZoneId(domain)` auto-discovers the hosted zone via `ListHostedZonesByName`, walking up to parent zones for subdomains (e.g. `mail.example.com` resolves to the `example.com` zone). Resolved zone IDs are memoized per-process. Returns `undefined` when no zone matches; `verifyDomainOwnership` then returns `false` and `setupDomainDNS` throws
 
 **API Key System** (`src/lib/api-keys.ts`):
 - Format: `mrs_{keyId}_{secretPart}`
@@ -167,8 +167,8 @@ DNS_PROVIDER=digitalocean        # or "route53"; defaults to "digitalocean"
 # DigitalOcean (required when DNS_PROVIDER=digitalocean)
 DO_API_TOKEN=...
 
-# Route53 (required when DNS_PROVIDER=route53)
-AWS_HOSTED_ZONE_ID=...           # the hosted zone that owns the sending domains
+# Route53 (DNS_PROVIDER=route53)
+AWS_HOSTED_ZONE_ID=...           # optional — if unset, auto-discovered from the sending domain via ListHostedZonesByName (walks up to parent zones)
 
 # Security
 NEXTAUTH_SECRET=...

--- a/README.ko.md
+++ b/README.ko.md
@@ -66,7 +66,9 @@ DNS_PROVIDER=digitalocean
 # DigitalOcean DNS (DNS_PROVIDER=digitalocean 일 때 필수)
 DO_API_TOKEN=your-digitalocean-api-token
 
-# AWS Route53 (DNS_PROVIDER=route53 일 때 필수)
+# AWS Route53 (DNS_PROVIDER=route53). AWS_HOSTED_ZONE_ID 는 선택입니다 —
+# 미설정 시 발송 도메인으로부터 ListHostedZonesByName 을 통해 hosted zone 을
+# 자동 탐지하며, 서브도메인은 parent zone 까지 walk-up 합니다.
 # AWS_HOSTED_ZONE_ID=Z0123456789ABCDEFGHIJ
 
 # 관리자
@@ -137,7 +139,10 @@ npm run dev
 ### 옵션 B — AWS Route53
 
 1. 발송 도메인의 hosted zone 을 생성하거나 기존 zone 을 선택합니다
-2. 동일 IAM user (또는 별도 user) 에 Route53 statement 를 추가합니다:
+2. 동일 IAM user (또는 별도 user) 에 Route53 statement 를 추가합니다.
+   `route53:ListHostedZonesByName` 을 포함하면 발송 도메인으로부터
+   hosted zone 을 자동 탐지할 수 있습니다 (다중 zone 을 자동 탐지하려면
+   `Resource` 를 `*` 로 넓힐 수 있음):
    ```json
    {
      "Version": "2012-10-17",
@@ -146,6 +151,7 @@ npm run dev
          "Effect": "Allow",
          "Action": [
            "route53:GetHostedZone",
+           "route53:ListHostedZonesByName",
            "route53:ListResourceRecordSets",
            "route53:ChangeResourceRecordSets"
          ],
@@ -157,6 +163,10 @@ npm run dev
 3. 환경변수 설정:
    ```env
    DNS_PROVIDER=route53
+   # AWS_HOSTED_ZONE_ID 는 선택입니다 — 미설정 시 발송 도메인으로부터
+   # ListHostedZonesByName 을 통해 hosted zone 을 자동 탐지합니다
+   # (서브도메인은 parent zone 까지 walk-up — 예: mail.example.com 은
+   # example.com zone 으로 매칭).
    AWS_HOSTED_ZONE_ID=Z0123456789ABCDEFGHIJ
    # AWS_REGION / AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY 는 SES 와 공유
    ```
@@ -287,8 +297,9 @@ npm run test:coverage       # 커버리지 리포트
 
 **Q: Route53 DNS 자동화가 동작하지 않습니다**
 
-- ✅ `AWS_HOSTED_ZONE_ID` 가 설정되어 있는지 확인하세요. 미설정 시 `verifyDomainOwnership` 는 `false` 를 반환하고 `setupDomainDNS` 는 throw 합니다
-- ✅ IAM user 가 `route53:GetHostedZone`, `route53:ListResourceRecordSets`, `route53:ChangeResourceRecordSets` 권한을 가져야 합니다
+- ✅ `AWS_HOSTED_ZONE_ID` 는 선택입니다 — 미설정 시 발송 도메인으로부터 `ListHostedZonesByName` 을 통해 hosted zone 을 자동 탐지합니다 (서브도메인은 parent zone 까지 walk-up). `verifyDomainOwnership` 는 `false` 를 반환하고 `setupDomainDNS` 는 계정에 매칭되는 hosted zone 이 전혀 없을 때만 throw 합니다
+- ✅ IAM user 가 `route53:GetHostedZone`, `route53:ListHostedZonesByName`, `route53:ListResourceRecordSets`, `route53:ChangeResourceRecordSets` 권한을 가져야 합니다
+- ✅ 자동 탐지 테스트: `aws route53 list-hosted-zones-by-name --dns-name yourdomain.com.`
 - ✅ zone 테스트: `aws route53 get-hosted-zone --id YOUR_HOSTED_ZONE_ID`
 
 **Q: 도메인 verify 가 "pending" 에서 멈춰있습니다**
@@ -445,4 +456,4 @@ MIT — 전문은 [LICENSE](./LICENSE) 를 참조하세요. 원작자의 copyrig
 - [ ] SMTP 서버 지원
 - [ ] 메일 캠페인 관리
 - [ ] Cloudflare DNS provider (`DNS_PROVIDER` 의 세 번째 옵션)
-- [ ] Route53 hosted-zone 자동 탐지 (`AWS_HOSTED_ZONE_ID` 환경변수 생략)
+- [x] Route53 hosted-zone 자동 탐지 (`AWS_HOSTED_ZONE_ID` 환경변수 생략)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ DNS_PROVIDER=digitalocean
 # DigitalOcean DNS (required when DNS_PROVIDER=digitalocean)
 DO_API_TOKEN=your-digitalocean-api-token
 
-# AWS Route53 (required when DNS_PROVIDER=route53)
+# AWS Route53 (DNS_PROVIDER=route53). AWS_HOSTED_ZONE_ID is optional —
+# if unset, the matching hosted zone is auto-discovered from the sending
+# domain via ListHostedZonesByName, walking up to parent zones if needed.
 # AWS_HOSTED_ZONE_ID=Z0123456789ABCDEFGHIJ
 
 # Admin
@@ -137,7 +139,10 @@ Pick whichever provider hosts your sending domain. The active provider is chosen
 ### Option B — AWS Route53
 
 1. Create or pick an existing hosted zone for your sending domain
-2. Attach a Route53 statement to the same IAM user (or a separate one):
+2. Attach a Route53 statement to the same IAM user (or a separate one).
+   Include `route53:ListHostedZonesByName` so the hosted zone can be
+   auto-discovered from the sending domain (and the resource constraint
+   can be widened to `*` if you want discovery across multiple zones):
    ```json
    {
      "Version": "2012-10-17",
@@ -146,6 +151,7 @@ Pick whichever provider hosts your sending domain. The active provider is chosen
          "Effect": "Allow",
          "Action": [
            "route53:GetHostedZone",
+           "route53:ListHostedZonesByName",
            "route53:ListResourceRecordSets",
            "route53:ChangeResourceRecordSets"
          ],
@@ -157,6 +163,10 @@ Pick whichever provider hosts your sending domain. The active provider is chosen
 3. Set environment variables:
    ```env
    DNS_PROVIDER=route53
+   # AWS_HOSTED_ZONE_ID is optional — if unset, the matching hosted zone
+   # is auto-discovered from the sending domain via ListHostedZonesByName
+   # (walking up to parent zones for subdomains, e.g. mail.example.com
+   # resolves to the example.com zone).
    AWS_HOSTED_ZONE_ID=Z0123456789ABCDEFGHIJ
    # AWS_REGION / AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY are shared with SES
    ```
@@ -287,8 +297,9 @@ For end-to-end verification against real AWS, send a test email from the dashboa
 
 **Q: Route53 DNS automation not working**
 
-- ✅ Make sure `AWS_HOSTED_ZONE_ID` is set; `verifyDomainOwnership` returns `false` and `setupDomainDNS` throws when it is missing
-- ✅ The IAM user needs `route53:GetHostedZone`, `route53:ListResourceRecordSets`, and `route53:ChangeResourceRecordSets`
+- ✅ `AWS_HOSTED_ZONE_ID` is optional — if unset, the zone is auto-discovered from the sending domain via `ListHostedZonesByName` (walking up to parent zones). `verifyDomainOwnership` returns `false` and `setupDomainDNS` throws only when no matching hosted zone exists in the account
+- ✅ The IAM user needs `route53:GetHostedZone`, `route53:ListHostedZonesByName`, `route53:ListResourceRecordSets`, and `route53:ChangeResourceRecordSets`
+- ✅ Test discovery: `aws route53 list-hosted-zones-by-name --dns-name yourdomain.com.`
 - ✅ Test the zone: `aws route53 get-hosted-zone --id YOUR_HOSTED_ZONE_ID`
 
 **Q: Domain verification stuck at "pending"**
@@ -445,4 +456,4 @@ MIT — see [LICENSE](./LICENSE) for the full text. The original author's copyri
 - [ ] SMTP server support
 - [ ] Email campaign management
 - [ ] Cloudflare DNS provider (third option behind `DNS_PROVIDER`)
-- [ ] Hosted-zone auto-discovery for Route53 (skip the explicit `AWS_HOSTED_ZONE_ID` env)
+- [x] Hosted-zone auto-discovery for Route53 (skip the explicit `AWS_HOSTED_ZONE_ID` env)

--- a/docs/plan/005-route53-zone-auto-discovery.md
+++ b/docs/plan/005-route53-zone-auto-discovery.md
@@ -1,0 +1,166 @@
+# 005-route53-zone-auto-discovery
+
+## 개요
+
+- **이슈**: [#11](https://github.com/Orchemi/my-resend/issues/11)
+- **브랜치**: `feat/11`
+- **상태**: 진행 중
+- **생성일**: 2026-04-26
+- **선행**: PR [#5](https://github.com/Orchemi/my-resend/pull/5) (Route53 + DNS_PROVIDER 추상화), [#8](https://github.com/Orchemi/my-resend/pull/8) / [#10](https://github.com/Orchemi/my-resend/pull/10) (digitalocean/ses lazy env capture)
+
+본 작업은 두 개의 작은 변경을 묶는다 — 둘 다 `route53.ts` 한 파일 안에서 끝나고 같은 책임 영역 (Route53 provider 의 env 처리) 이라 한 PR.
+
+1. **Hosted zone auto-discovery** — `AWS_HOSTED_ZONE_ID` 미설정 시 도메인으로부터 자동 탐지 (UX 개선, README roadmap 등재)
+2. **`Route53Client` lazy 화** — sister 모듈 (`digitalocean.ts`, `ses.ts`) 와 동일한 lazy env capture 패턴으로 정합
+
+## 배경
+
+### 1. Auto-discovery
+
+현재 `route53.ts.verifyDomainOwnership(domain)` 은 `domain` 인자를 무시하고 `AWS_HOSTED_ZONE_ID` env 만 본다. 이 설계는 단순하지만, operator 가 zone ID 를 손으로 복사해서 env 에 넣어야 하는 boilerplate 가 남는다. AWS 관행상 한 root 도메인당 hosted zone 1개가 일반적이라, SDK 가 자동 탐지할 수 있는 정보다.
+
+또한 sending domain 이 subdomain 인 경우 (예: `mail.example.com`) 보통은 `example.com.` zone 안에 위치한다. parent zone 매칭으로 이 케이스를 자동 처리.
+
+### 2. Lazy env capture
+
+PR #8 (digitalocean), PR #10 (ses) 가 module-load 캡처를 lazy getter 로 바꿨지만 `route53.ts` 는 여전히 module-load 에 `Route53Client` 를 생성한다 (line 30). 같은 패턴 비대칭. 본 작업에서 `getRoute53Client()` 도입.
+
+## 목표
+
+- [ ] `resolveHostedZoneId(domain): Promise<string | undefined>` 신설:
+  - `AWS_HOSTED_ZONE_ID` 설정 → 그대로 반환 (SDK 호출 0)
+  - 미설정 → `ListHostedZonesByNameCommand` 로 도메인 매칭. exact match 없으면 parent 도메인으로 재시도 (root 까지 cap)
+  - 결과를 in-process Map 으로 memoize (도메인별)
+- [ ] `verifyDomainOwnership` 가 `resolveHostedZoneId(domain)` 사용
+- [ ] `setupDomainDNS` 가 `resolveHostedZoneId(domain)` 사용
+- [ ] `Route53Client` lazy 화 — `getRoute53Client()` 도입, 모든 호출처 갱신
+- [ ] 단위 테스트:
+  - 신규: resolveHostedZoneId 의 4 케이스 (env 사용, exact match, parent match, no match)
+  - 신규: memoize 동작 (같은 도메인 재호출 시 SDK 호출 0)
+  - 기존 10 케이스 무회귀
+- [ ] README + CLAUDE.md 갱신: `AWS_HOSTED_ZONE_ID` 를 optional 로, discovery 규칙 1줄 설명
+- [ ] `npm run lint && npm test && npm run build` 모두 통과
+
+## 설계
+
+### 접근 방식
+
+#### resolveHostedZoneId 알고리즘
+
+```
+function resolveHostedZoneId(domain):
+  1. env AWS_HOSTED_ZONE_ID 있으면 → 반환 (SDK X)
+  2. cache hit (domain → id) 있으면 → 반환
+  3. SDK 호출:
+     - candidate = domain
+     - while candidate has at least one dot:
+         response = ListHostedZonesByName({DNSName: candidate + ".", MaxItems: 1})
+         if response.HostedZones[0].Name == candidate + ".":
+             cache[domain] = response.HostedZones[0].Id (zone ID, sans /hostedzone/ prefix)
+             return cached
+         candidate = strip first label (mail.example.com → example.com)
+     return undefined
+```
+
+- `ListHostedZonesByName` 는 lexicographic 순서로 반환하므로, `DNSName=example.com.` 으로 호출하면 `example.com.` 또는 그 다음 zone 이 첫 결과로 옴. 첫 결과의 Name 이 정확히 `<candidate>.` 인지 비교해야 안전.
+- Zone ID 형식: SDK 응답은 `/hostedzone/Z0123...` 형태. 이후 `GetHostedZone` / `ChangeResourceRecordSets` 호출 시 `Z0123...` 만 필요하므로 prefix 제거.
+
+#### 캐싱
+
+- module-level `Map<string, string>` (도메인 → zone ID).
+- env 설정된 경우 cache 미사용 (env 가 single source of truth).
+- cache 무효화 mechanism 없음 — process lifetime 동안 유지. 도메인이 zone 이동되는 경우는 매우 드물고, 발생 시 재시작으로 해결.
+
+#### Lazy Route53Client
+
+`getRoute53Client(): Route53Client` 함수로 wrap. 매 호출마다 `new Route53Client({...})`. `digitalocean.ts.getDoClient()` 와 동일 패턴.
+
+### 변경 범위
+
+```
+my-resend/
+├── src/lib/
+│   ├── route53.ts                              # resolveHostedZoneId + lazy client + 호출처 갱신
+│   └── __tests__/
+│       └── route53.test.ts                     # 신규 케이스 추가 (~5)
+├── README.md                                   # AWS_HOSTED_ZONE_ID optional 표시 + 1줄 설명
+├── README.ko.md                                # 동일 (parity)
+├── CLAUDE.md                                   # env 섹션 갱신
+└── docs/plan/
+    └── 005-route53-zone-auto-discovery.md      # 본 문서
+```
+
+**무수정**:
+- `dns-provider.ts`, `digitalocean.ts`, `ses.ts`, `domains.ts` — Route53 의 외부 시그니처 (`verifyDomainOwnership`, `setupDomainDNS`) 무변경
+
+### 의사결정 기록
+
+| 결정 사항 | 선택지 | 결정 | 이유 |
+|-----------|--------|------|------|
+| env vs auto-discovery 우선순위 | A) env 우선 / B) auto 우선 / C) auto 만 | **A** | 명시적 설정이 항상 implicit 추론보다 우선. 또한 다중 zone 환경에서 operator 가 의도한 zone 을 콕 집을 수 있어야 함 |
+| Parent 매칭 | A) 정확히 한 단계만 / B) root 까지 walk-up / C) 매칭 안 함 | **B** | `mail.staging.example.com` 같은 다단 subdomain 도 단일 step 으로 부족. root 까지 시도가 자연스러움 |
+| 매칭 실패 처리 | A) throw / B) undefined 반환 → 기존 분기 (verify=false, setup=throw) 가 처리 | **B** | 기존 분기 로직 (env 미설정 시) 과 일관 |
+| Cache 정책 | A) 영구 (process 수명) / B) TTL 있음 / C) cache 없음 | **A** | zone 이동은 매우 드물고, 발생 시 재시작 cost 가 낮음. 복잡한 TTL 도입은 over-engineering |
+| Cache 키 | A) domain 원형 / B) zone Name 정규화 (trailing dot) | **A** | 입력 그대로가 단순. 호출자 입력의 다양성을 흡수 |
+| Lazy Route53Client 묶음 여부 | A) 본 PR 에서 같이 / B) 별도 PR | **A** | 같은 파일 한 줄 변경. 별도 PR 비용이 작업보다 큼. sister 모듈 패턴 통일 효과 |
+
+## 작업 단계
+
+### Phase 1: lazy Route53Client (작은 변경, 회귀 baseline 확보)
+
+- [ ] 상단 `const route53Client = new Route53Client({...})` 제거
+- [ ] `function getRoute53Client(): Route53Client` 도입
+- [ ] 4건 `route53Client.send(...)` → `getRoute53Client().send(...)`
+- [ ] 기존 10 테스트 통과 확인 (`mockClient(Route53Client)` 가 prototype 패치라 안전)
+
+### Phase 2: resolveHostedZoneId TDD
+
+- [ ] `__tests__/route53.test.ts` 에 신규 describe 추가 — `resolveHostedZoneId`
+- [ ] 케이스:
+  1. `AWS_HOSTED_ZONE_ID` 설정 → 그대로 반환, `ListHostedZonesByName` 호출 0
+  2. env 미설정 + exact match → 정상 zone ID 반환 (`/hostedzone/` prefix 제거 확인)
+  3. env 미설정 + parent match (`mail.example.com` → `example.com.`) → parent zone ID 반환
+  4. env 미설정 + 다단 subdomain parent match (`a.b.example.com` → `example.com.`)
+  5. env 미설정 + match 없음 → undefined
+  6. memoize: 같은 도메인 두 번 호출 → SDK 호출 1회만
+- [ ] 모든 케이스 RED → GREEN
+
+### Phase 3: 통합
+
+- [ ] `verifyDomainOwnership(domain)` 가 `resolveHostedZoneId(domain)` 사용
+  - 결과 undefined → false
+  - 결과 zone ID → 기존 `GetHostedZone` 흐름 (NoSuchHostedZone 처리 보존)
+- [ ] `setupDomainDNS(domain, dnsRecords)` 가 `resolveHostedZoneId(domain)` 사용
+  - 결과 undefined → throw (메시지: `AWS_HOSTED_ZONE_ID is not set and no matching hosted zone found for domain '<domain>'`)
+- [ ] 기존 통합 테스트 (`domains-dns-integration.test.ts`) 회귀 없음 확인
+
+### Phase 4: 문서 갱신
+
+- [ ] README.md 의 env table:
+  - `AWS_HOSTED_ZONE_ID` 행을 optional 로 표기 + "if unset, the zone is auto-discovered from the domain"
+  - DNS Provider Setup → 옵션 B (Route53) 섹션에 1줄 추가
+- [ ] README.ko.md 동일 (한국어 parity)
+- [ ] CLAUDE.md 의 env 섹션 + Route53 integration 섹션 1-2줄 갱신
+
+### Phase 5: 검증
+
+- [ ] `npm run lint`
+- [ ] `npm test --testPathPatterns='src/lib'` (105 + 신규 5-6 = ~110)
+- [ ] `npm run build`
+
+### Phase 6: 커밋 + PR
+
+- [ ] 관심사별 분리 가능하면 분리, 아니면 단일 commit
+- [ ] `/pr auto`
+
+## 진행 로그
+
+| 날짜 | 내용 | 비고 |
+|------|------|------|
+| 2026-04-26 | 이슈 #11, `feat/11` 브랜치, 본 plan 작성 | PR #10 직후 후속 |
+
+## 참고
+
+- AWS `ListHostedZonesByName`: <https://docs.aws.amazon.com/Route53/latest/APIReference/API_ListHostedZonesByName.html>
+- 직전 plan 004 (ses lazy): `docs/plan/004-ses-lazy-env-capture.md`
+- README roadmap 의 등재: "Hosted-zone auto-discovery for Route53"

--- a/src/lib/__tests__/route53.test.ts
+++ b/src/lib/__tests__/route53.test.ts
@@ -9,11 +9,17 @@ import { mockClient } from "aws-sdk-client-mock";
 import {
   Route53Client,
   GetHostedZoneCommand,
+  ListHostedZonesByNameCommand,
   ListResourceRecordSetsCommand,
   ChangeResourceRecordSetsCommand,
 } from "@aws-sdk/client-route-53";
 
-import { setupDomainDNS, verifyDomainOwnership } from "../route53";
+import {
+  resolveHostedZoneId,
+  setupDomainDNS,
+  verifyDomainOwnership,
+  __resetZoneIdCacheForTests,
+} from "../route53";
 import type { DnsProviderRecord } from "../dns-provider";
 
 const route53Mock = mockClient(Route53Client);
@@ -22,6 +28,7 @@ const ORIGINAL_HOSTED_ZONE_ID = process.env.AWS_HOSTED_ZONE_ID;
 
 beforeEach(() => {
   route53Mock.reset();
+  __resetZoneIdCacheForTests();
 });
 
 afterEach(() => {
@@ -33,8 +40,15 @@ afterEach(() => {
 });
 
 describe("verifyDomainOwnership", () => {
-  it("returns false (and never calls SDK) when AWS_HOSTED_ZONE_ID is unset", async () => {
+  it("returns false (without calling GetHostedZone) when env is unset and no zone matches the domain", async () => {
     delete process.env.AWS_HOSTED_ZONE_ID;
+    // Auto-discovery is exercised, but the account has no matching zone
+    // for example.com (or any parent). resolveHostedZoneId returns
+    // undefined, so verifyDomainOwnership short-circuits to false
+    // without invoking GetHostedZone.
+    route53Mock.on(ListHostedZonesByNameCommand).resolves({
+      HostedZones: [],
+    });
 
     const result = await verifyDomainOwnership("example.com");
 
@@ -101,8 +115,11 @@ describe("setupDomainDNS", () => {
     ).toHaveLength(0);
   });
 
-  it("throws when AWS_HOSTED_ZONE_ID is unset", async () => {
+  it("throws when env is unset and no hosted zone matches the domain", async () => {
     delete process.env.AWS_HOSTED_ZONE_ID;
+    route53Mock.on(ListHostedZonesByNameCommand).resolves({
+      HostedZones: [],
+    });
 
     await expect(
       setupDomainDNS("example.com", [
@@ -310,5 +327,162 @@ describe("setupDomainDNS", () => {
     await expect(setupDomainDNS("example.com", records)).rejects.toThrow(
       "InvalidChangeBatch"
     );
+  });
+});
+
+describe("resolveHostedZoneId", () => {
+  // The module-level memoization cache is shared across cases. Reset
+  // via the test-only export so each case starts cold; mockClient stays
+  // active because it patches the singleton Route53Client.prototype.
+  beforeEach(() => {
+    __resetZoneIdCacheForTests();
+    delete process.env.AWS_HOSTED_ZONE_ID;
+  });
+
+  it("returns the env value verbatim when AWS_HOSTED_ZONE_ID is set, without calling the SDK", async () => {
+    process.env.AWS_HOSTED_ZONE_ID = "Z123EXAMPLE";
+
+    const result = await resolveHostedZoneId("example.com");
+
+    expect(result).toBe("Z123EXAMPLE");
+    expect(
+      route53Mock.commandCalls(ListHostedZonesByNameCommand)
+    ).toHaveLength(0);
+  });
+
+  it("auto-discovers an exact-match hosted zone and strips the /hostedzone/ prefix", async () => {
+    route53Mock.on(ListHostedZonesByNameCommand).resolves({
+      HostedZones: [
+        {
+          Id: "/hostedzone/Z0EXACTMATCH",
+          Name: "example.com.",
+          CallerReference: "ref",
+        },
+      ],
+    });
+
+    const result = await resolveHostedZoneId("example.com");
+
+    expect(result).toBe("Z0EXACTMATCH");
+    const calls = route53Mock.commandCalls(ListHostedZonesByNameCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args[0].input).toMatchObject({
+      DNSName: "example.com.",
+      MaxItems: 1,
+    });
+  });
+
+  it("walks up to the parent zone for a one-level subdomain (mail.example.com -> example.com.)", async () => {
+    route53Mock
+      .on(ListHostedZonesByNameCommand, {
+        DNSName: "mail.example.com.",
+        MaxItems: 1,
+      })
+      .resolves({
+        // Lexicographically next zone — name does NOT match the candidate.
+        HostedZones: [
+          {
+            Id: "/hostedzone/Z0OTHER",
+            Name: "other.example.org.",
+            CallerReference: "ref",
+          },
+        ],
+      })
+      .on(ListHostedZonesByNameCommand, {
+        DNSName: "example.com.",
+        MaxItems: 1,
+      })
+      .resolves({
+        HostedZones: [
+          {
+            Id: "/hostedzone/Z0PARENT",
+            Name: "example.com.",
+            CallerReference: "ref",
+          },
+        ],
+      });
+
+    const result = await resolveHostedZoneId("mail.example.com");
+
+    expect(result).toBe("Z0PARENT");
+    expect(
+      route53Mock.commandCalls(ListHostedZonesByNameCommand)
+    ).toHaveLength(2);
+  });
+
+  it("walks up multiple labels for a multi-level subdomain (a.b.example.com -> example.com.)", async () => {
+    route53Mock
+      .on(ListHostedZonesByNameCommand, {
+        DNSName: "a.b.example.com.",
+        MaxItems: 1,
+      })
+      .resolves({ HostedZones: [] })
+      .on(ListHostedZonesByNameCommand, {
+        DNSName: "b.example.com.",
+        MaxItems: 1,
+      })
+      .resolves({ HostedZones: [] })
+      .on(ListHostedZonesByNameCommand, {
+        DNSName: "example.com.",
+        MaxItems: 1,
+      })
+      .resolves({
+        HostedZones: [
+          {
+            Id: "/hostedzone/Z0ROOT",
+            Name: "example.com.",
+            CallerReference: "ref",
+          },
+        ],
+      });
+
+    const result = await resolveHostedZoneId("a.b.example.com");
+
+    expect(result).toBe("Z0ROOT");
+    expect(
+      route53Mock.commandCalls(ListHostedZonesByNameCommand)
+    ).toHaveLength(3);
+  });
+
+  it("returns undefined when no hosted zone matches the domain or any parent", async () => {
+    route53Mock.on(ListHostedZonesByNameCommand).resolves({
+      HostedZones: [
+        {
+          Id: "/hostedzone/Z0UNRELATED",
+          Name: "unrelated.example.net.",
+          CallerReference: "ref",
+        },
+      ],
+    });
+
+    const result = await resolveHostedZoneId("mail.example.com");
+
+    expect(result).toBeUndefined();
+    // mail.example.com -> example.com -> com (1 label, walk stops). At
+    // least one SDK call must have been issued.
+    expect(
+      route53Mock.commandCalls(ListHostedZonesByNameCommand).length
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("memoizes resolved zone IDs per domain (second call issues no SDK request)", async () => {
+    route53Mock.on(ListHostedZonesByNameCommand).resolves({
+      HostedZones: [
+        {
+          Id: "/hostedzone/Z0CACHED",
+          Name: "example.com.",
+          CallerReference: "ref",
+        },
+      ],
+    });
+
+    const first = await resolveHostedZoneId("example.com");
+    const second = await resolveHostedZoneId("example.com");
+
+    expect(first).toBe("Z0CACHED");
+    expect(second).toBe("Z0CACHED");
+    expect(
+      route53Mock.commandCalls(ListHostedZonesByNameCommand)
+    ).toHaveLength(1);
   });
 });

--- a/src/lib/route53.ts
+++ b/src/lib/route53.ts
@@ -5,8 +5,12 @@
  * that `digitalocean.ts` exposes, normalized to the unified
  * `DnsProviderRecord` shape consumed by `dns-provider.ts`.
  *
- * Required env:
- *   - `AWS_HOSTED_ZONE_ID` — the hosted zone in which records are managed.
+ * Env:
+ *   - `AWS_HOSTED_ZONE_ID` (optional) — the hosted zone in which records
+ *     are managed. If unset, the matching hosted zone is auto-discovered
+ *     from the sending domain via `ListHostedZonesByName`, walking up to
+ *     parent zones for subdomains (e.g. `mail.example.com` resolves to
+ *     the `example.com` zone).
  *   - `AWS_REGION` (optional, defaults to `us-east-1`; Route53 is global
  *     but the SDK still wants a region).
  *   - `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (or any other AWS
@@ -18,6 +22,7 @@
 import {
   Route53Client,
   GetHostedZoneCommand,
+  ListHostedZonesByNameCommand,
   ListResourceRecordSetsCommand,
   ChangeResourceRecordSetsCommand,
   type Change,
@@ -27,34 +32,118 @@ import {
 
 import type { DnsProviderRecord } from "./dns-provider";
 
-const route53Client = new Route53Client({
-  region: process.env.AWS_REGION || "us-east-1",
-});
-
-function getHostedZoneId(): string | undefined {
-  return process.env.AWS_HOSTED_ZONE_ID;
+/**
+ * Build a fresh Route53 client per call. Mirrors the lazy pattern used in
+ * `digitalocean.ts` (PR #8) and `ses.ts` (PR #10): credentials and region
+ * are read from `process.env` at call time so credential rotation is safe
+ * and tests can mutate AWS env between cases without re-importing the
+ * module. Client construction is config + middleware wiring only — no
+ * network work — so per-call instantiation is negligible compared to
+ * the actual `.send()` call that follows.
+ */
+function getRoute53Client(): Route53Client {
+  return new Route53Client({
+    region: process.env.AWS_REGION || "us-east-1",
+  });
 }
 
 /**
- * Verify that the configured hosted zone exists and is accessible. The
- * hosted zone is treated as the source of truth for "which domains do
- * we own" — operators map subdomains under one or more zones at the
- * AWS account level.
+ * Per-process memoization of `domain -> hosted zone ID` lookups. Hosted
+ * zones rarely move between accounts, so a process-lifetime cache is
+ * acceptable — restart to invalidate. The cache is keyed on the input
+ * domain (not the matched zone name) so callers can pass any form they
+ * like and still hit the cache cheaply.
+ */
+const zoneIdCache = new Map<string, string>();
+
+/**
+ * Resolve the Route53 hosted zone ID that owns `domain`.
+ *
+ * Resolution order:
+ *   1. If `AWS_HOSTED_ZONE_ID` is set, return it verbatim (no SDK call).
+ *      Explicit configuration always wins so operators can pin a
+ *      specific zone in multi-zone accounts.
+ *   2. If we previously resolved this exact domain, return the cached
+ *      zone ID (no SDK call).
+ *   3. Walk up the domain labels — `mail.example.com` -> `example.com`
+ *      -> stop — calling `ListHostedZonesByName` for each candidate.
+ *      The first candidate whose zone Name (with trailing dot) matches
+ *      a hosted zone in the account wins. The matched zone ID is
+ *      cached and returned without the `/hostedzone/` SDK prefix.
+ *   4. If no candidate matches any hosted zone, returns `undefined`
+ *      so callers can fall back to their existing "no zone" branches
+ *      (verify -> false, setup -> throw).
+ */
+export async function resolveHostedZoneId(
+  domain: string
+): Promise<string | undefined> {
+  const envValue = process.env.AWS_HOSTED_ZONE_ID;
+  if (envValue) {
+    return envValue;
+  }
+
+  const cached = zoneIdCache.get(domain);
+  if (cached) {
+    return cached;
+  }
+
+  let candidate = domain;
+  // Walk up while the candidate has at least one dot — i.e. has a
+  // parent. A bare TLD like `com` is never a sensible hosted zone for
+  // sending, so we stop there.
+  while (candidate.includes(".")) {
+    const dnsName = `${candidate}.`;
+    const response = await getRoute53Client().send(
+      new ListHostedZonesByNameCommand({
+        DNSName: dnsName,
+        MaxItems: 1,
+      })
+    );
+
+    const firstZone = response.HostedZones?.[0];
+    if (firstZone?.Name === dnsName && firstZone.Id) {
+      const stripped = firstZone.Id.replace(/^\/hostedzone\//, "");
+      zoneIdCache.set(domain, stripped);
+      return stripped;
+    }
+
+    // Strip the leftmost label and try the parent.
+    const nextDot = candidate.indexOf(".");
+    candidate = candidate.slice(nextDot + 1);
+  }
+
+  return undefined;
+}
+
+/**
+ * Test-only: clear the in-process hosted-zone cache so each test case
+ * starts cold. Underscored to signal "internal" — not part of the
+ * public API. Production code should never call this.
+ */
+export function __resetZoneIdCacheForTests(): void {
+  zoneIdCache.clear();
+}
+
+/**
+ * Verify that the hosted zone owning `domain` exists and is accessible.
+ *
+ * The hosted zone is resolved via `resolveHostedZoneId(domain)`, which
+ * either returns the explicit `AWS_HOSTED_ZONE_ID` env value or
+ * auto-discovers a zone via `ListHostedZonesByName` (walking up to
+ * parent zones for subdomains). When no zone can be resolved we return
+ * `false` — the same answer the original env-only implementation gave
+ * when `AWS_HOSTED_ZONE_ID` was unset.
  */
 export async function verifyDomainOwnership(
   domain: string
 ): Promise<boolean> {
-  // The hosted zone is the source of truth; the domain argument exists
-  // for parity with other providers (digitalocean.ts uses it directly).
-  // Logged at debug level so it's discoverable but not noisy.
-  void domain;
-  const hostedZoneId = getHostedZoneId();
+  const hostedZoneId = await resolveHostedZoneId(domain);
   if (!hostedZoneId) {
     return false;
   }
 
   try {
-    const response = await route53Client.send(
+    const response = await getRoute53Client().send(
       new GetHostedZoneCommand({ Id: hostedZoneId })
     );
     return Boolean(response.HostedZone);
@@ -87,10 +176,10 @@ export async function setupDomainDNS(
     return [];
   }
 
-  const hostedZoneId = getHostedZoneId();
+  const hostedZoneId = await resolveHostedZoneId(domain);
   if (!hostedZoneId) {
     throw new Error(
-      "AWS_HOSTED_ZONE_ID is not set; cannot manage Route53 DNS records."
+      `AWS_HOSTED_ZONE_ID is not set and no matching hosted zone found for domain '${domain}'.`
     );
   }
 
@@ -115,7 +204,7 @@ export async function setupDomainDNS(
     return [];
   }
 
-  await route53Client.send(
+  await getRoute53Client().send(
     new ChangeResourceRecordSetsCommand({
       HostedZoneId: hostedZoneId,
       ChangeBatch: {
@@ -143,7 +232,7 @@ async function listAllResourceRecordSets(
 
   // Cap to avoid runaway loops in pathological cases.
   for (let i = 0; i < 50; i++) {
-    const response = await route53Client.send(
+    const response = await getRoute53Client().send(
       new ListResourceRecordSetsCommand({
         HostedZoneId: hostedZoneId,
         StartRecordName: startRecordName,


### PR DESCRIPTION
## 요약
- `AWS_HOSTED_ZONE_ID` 가 이제 optional. 미설정 시 Route53 provider 가 `ListHostedZonesByName` 으로 sending domain 의 hosted zone 을 자동 탐지, parent zone 까지 walk-up (예: `mail.example.com` → `example.com.`).
- `Route53Client` 도 호출-시점 `getRoute53Client()` 헬퍼로 이동 — `digitalocean.ts` (PR #8) 와 `ses.ts` (PR #10) 의 동일 lazy env-capture 패턴. 이제 SDK-backed 3 모듈이 동일 동작.

Closes #11.

## 상세

### Auto-discovery

`resolveHostedZoneId(domain)` 이 `verifyDomainOwnership` 과 `setupDomainDNS` 양쪽의 단일 진입점:

1. `AWS_HOSTED_ZONE_ID` 가 set 이면 그대로 반환 (SDK 호출 없음). 명시적 설정이 항상 우선이라 multi-zone operator 가 의도한 zone 을 콕 집을 수 있음.
2. 미설정이면 `ListHostedZonesByNameCommand` 를 `DNSName: \"<domain>.\"` 로 호출, 첫 결과의 `Name` 이 `<domain>.` 와 정확히 일치하는지 확인, miss 시 DNS label 한 단계씩 walk up (`a.b.example.com` → `b.example.com` → `example.com`).
3. 해석된 id 를 module-level `Map<domain, zoneId>` 에 cache — process 내 반복 lookup 시 API 재호출 없음.

zone 미발견 시 `verifyDomainOwnership` 은 `false` 반환, `setupDomainDNS` 는 도메인을 명시한 descriptive 메시지로 throw — env-only 경로가 이전에 가졌던 fail-shape 동일.

README 의 IAM 정책에 기존 zone-scoped 권한과 함께 `route53:ListHostedZonesByName` 추가; 이 권한은 account-level 이라 resource-constrain 불가, 코멘트로 명시.

### Lazy `Route53Client`

module-level `const route53Client = new Route53Client({ region: process.env.AWS_REGION || 'us-east-1' })` 를 호출-시점 `function getRoute53Client(): Route53Client` 로 교체. `Route53Client` 생성은 config + middleware-stack 와이어링만 (network 작업 없음) 이라 per-call 비용 무시 가능.

`digitalocean.ts` (PR #8) 와 `ses.ts` (PR #10) 에 이미 적용된 동일 패턴. SDK-backed 3 모듈이 모두 호출-시점에 env 를 읽어 credential rotation 에 안전하고 테스트 surface 통일.

## 변경 파일
```
docs/plan/
└── 005-route53-zone-auto-discovery.md       # 신규 — 두 변경 모두 기록한 plan
src/lib/
├── route53.ts                               # resolveHostedZoneId + lazy client + 통합
└── __tests__/
    └── route53.test.ts                      # 6 신규 케이스 + 2 기존 semantics 갱신
README.md                                     # AWS_HOSTED_ZONE_ID optional, IAM 갱신, roadmap 체크
README.ko.md                                  # parity 번역
CLAUDE.md                                     # env 섹션 + Route53 integration 노트
```

## 커밋
- [`a9c53e5`](https://github.com/Orchemi/my-resend/commit/a9c53e5) docs(plan): add 005 Route53 hosted-zone auto-discovery plan
- [`d0d20cc`](https://github.com/Orchemi/my-resend/commit/d0d20cc) feat(route53): auto-discover hosted zone from sending domain

## 테스트 계획
- [x] `npm run lint` — warning/error 0
- [x] `npm test -- --testPathPatterns='src/lib'` — 7 suites / **111 tests 통과** (기존 105 + 신규 6)
- [x] `npm run build` — production build OK
- [x] 기존 `domains-dns-integration.test.ts` (env set 으로 Route53 경로) 그대로 통과 — env 우선순위 보존
- [x] CI 에서 라이브 AWS 호출 없음 — `aws-sdk-client-mock` 가 모든 Route53 command 가로챔

## 본 PR 범위 밖 (별도 PR)
- Cloudflare DNS provider (roadmap entry)
- `digitalocean.ts` 내부 `DNSRecord` (with optional `description?`) 통합
- 사전 존재 tsc 에러 (테스트 파일들)