### PR TITLE
DigitalOcean DNSRecord 를 DnsProviderRecord 로 통합

### DIFF
--- a/docs/plan/006-consolidate-dns-record-type.md
+++ b/docs/plan/006-consolidate-dns-record-type.md
@@ -1,0 +1,91 @@
+# 006-consolidate-dns-record-type
+
+## 개요
+
+- **이슈**: [#13](https://github.com/Orchemi/my-resend/issues/13)
+- **브랜치**: `feat/13`
+- **상태**: 진행 중
+- **생성일**: 2026-04-26
+- **선행**: [PR #8](https://github.com/Orchemi/my-resend/pull/8) — 타입 통합 1차 (domains.ts 의 `DNSRecord` 제거). 본 작업은 그 때 보류했던 `digitalocean.ts` 내부 `DNSRecord` 까지 정리.
+
+## 배경
+
+PR #8 에서 `domains.ts` 의 로컬 `DNSRecord` 를 제거하고 `DnsProviderRecord` 로 단일화했지만, `digitalocean.ts` 의 로컬 `DNSRecord` 는 의도적으로 보존했었다. 이유 (당시 메모):
+
+> "digitalocean.ts 의 `DNSRecord` 는 외부 type-import 가 0건이라 (네임스페이스 import 만), 모듈 internal alias 로 해석 가능하고, `description?: string` optional 필드를 가지고 있어 `DnsProviderRecord` 와 정확히 동일하지 않음 (description 보존 의도)."
+
+이제 그 잔여를 정리한다. `description?` 을 `DnsProviderRecord` 의 선택 필드로 promote 하면 두 모듈의 타입이 정확히 일치하여 정합화 가능.
+
+## 목표
+
+- [ ] `dns-provider.ts` 의 `DnsProviderRecord` 에 `description?: string` 추가
+- [ ] `digitalocean.ts` 의 로컬 `DNSRecord` interface 제거 → `import type { DnsProviderRecord } from "./dns-provider"`
+- [ ] 함수 시그니처 4건 갱신: `createDNSRecord`, `updateDNSRecord`, `setupDomainDNS`, `formatDNSInstructions` (+ `Partial<DNSRecord>` 1건)
+- [ ] 기존 111 lib 테스트 무회귀 (신규 테스트 없음 — 순수 타입 cleanup)
+- [ ] `npm run lint && npm test && npm run build` 통과
+
+## 설계
+
+### 접근 방식
+
+`DnsProviderRecord` 에 `description` 을 선택 필드로 추가하는 것이 가장 자연스럽다:
+
+- ses.ts 의 `generateDNSRecords()` 가 이미 모든 record 에 description 을 set (e.g., "SES Domain Verification", "DKIM Record (...)")
+- digitalocean.ts 의 `formatDNSInstructions()` 가 description 을 읽어 사용자용 instructions 출력
+- Route53 path 는 description 을 사용하지 않지만, optional 필드라 무관
+
+### 변경 범위
+
+```
+my-resend/
+├── src/lib/
+│   ├── dns-provider.ts                      # DnsProviderRecord 에 description?: string 추가
+│   └── digitalocean.ts                      # 로컬 DNSRecord 제거, DnsProviderRecord import
+└── docs/plan/
+    └── 006-consolidate-dns-record-type.md   # 본 문서
+```
+
+**무수정**:
+- ses.ts (generateDNSRecords 의 return 형태가 이미 호환)
+- domains.ts (이미 PR #8 에서 정리됨)
+- route53.ts (DnsProviderRecord 사용 중, description 무시)
+- 테스트 파일 (타입 변경만이므로 행동 무변화 → 회귀 테스트로 검증)
+
+### 의사결정 기록
+
+| 결정 사항 | 선택지 | 결정 | 이유 |
+|-----------|--------|------|------|
+| description 위치 | A) DnsProviderRecord 의 optional 필드 / B) 별도 ExtendedDnsProviderRecord 타입 / C) 함수-local interface | **A** | 동일 데이터 모양에 두 이름 두는 것이 PR #8 이전 상태로 회귀. optional 필드는 cost 없음 |
+| ses.ts 의 generateDNSRecords return 타입 | A) DnsProviderRecord[] 명시 / B) 추론 (현재 상태 — 익명 객체 array) | **B** | return 명시 안 하는 것이 현재 working 상태. 명시는 별도 cleanup PR 후보 |
+
+## 작업 단계
+
+### Phase 1: 타입 변경
+
+- [ ] `src/lib/dns-provider.ts` 의 `DnsProviderRecord` interface 에 `description?: string` 추가 (JSDoc 1줄로 의미 설명)
+- [ ] `src/lib/digitalocean.ts`:
+  - 로컬 `DNSRecord` interface 제거
+  - 상단에 `import type { DnsProviderRecord } from "./dns-provider"` 추가
+  - 함수 시그니처 4건의 `DNSRecord` → `DnsProviderRecord` (Partial 사이트 포함)
+
+### Phase 2: 검증
+
+- [ ] `npm run lint`
+- [ ] `npm test --testPathPatterns='src/lib'` (111 → 111)
+- [ ] `npm run build`
+
+### Phase 3: 커밋 + PR
+
+- [ ] 2 commits: docs(plan) + refactor(types)
+- [ ] `/pr auto`
+
+## 진행 로그
+
+| 날짜 | 내용 | 비고 |
+|------|------|------|
+| 2026-04-26 | 이슈 #13, `feat/13` 브랜치, 본 plan 작성 | PR #12 직후 후속 |
+
+## 참고
+
+- 직전 plan 005: `docs/plan/005-route53-zone-auto-discovery.md`
+- 1차 타입 통합 PR: <https://github.com/Orchemi/my-resend/pull/8>

--- a/src/lib/digitalocean.ts
+++ b/src/lib/digitalocean.ts
@@ -1,4 +1,5 @@
 import axios, { type AxiosInstance } from "axios";
+import type { DnsProviderRecord } from "./dns-provider";
 
 const DO_API_BASE = "https://api.digitalocean.com/v2";
 
@@ -66,14 +67,6 @@ async function retryRequest<T>(
   }
 
   throw lastError;
-}
-
-export interface DNSRecord {
-  type: string;
-  name: string;
-  value: string;
-  ttl: number;
-  description?: string;
 }
 
 export interface DODomainRecord {
@@ -145,7 +138,7 @@ export async function getDomainRecords(
 
 export async function createDNSRecord(
   domain: string,
-  record: DNSRecord
+  record: DnsProviderRecord
 ): Promise<DODomainRecord> {
   if (!getApiToken()) {
     throw new Error("Digital Ocean API token not configured");
@@ -202,7 +195,7 @@ export async function createDNSRecord(
 export async function updateDNSRecord(
   domain: string,
   recordId: number,
-  record: Partial<DNSRecord>
+  record: Partial<DnsProviderRecord>
 ): Promise<DODomainRecord> {
   if (!getApiToken()) {
     throw new Error("Digital Ocean API token not configured");
@@ -262,7 +255,7 @@ export async function deleteDNSRecord(
 
 export async function setupDomainDNS(
   domain: string,
-  dnsRecords: DNSRecord[]
+  dnsRecords: DnsProviderRecord[]
 ): Promise<DODomainRecord[]> {
   if (!getApiToken()) {
     console.warn(
@@ -376,7 +369,7 @@ export async function verifyDomainOwnership(domain: string): Promise<boolean> {
   }
 }
 
-export function formatDNSInstructions(dnsRecords: DNSRecord[]): string {
+export function formatDNSInstructions(dnsRecords: DnsProviderRecord[]): string {
   let instructions =
     "Please create the following DNS records in your domain provider:\n\n";
 

--- a/src/lib/dns-provider.ts
+++ b/src/lib/dns-provider.ts
@@ -20,15 +20,22 @@ import * as route53 from "./route53";
 export type DnsProviderName = "digitalocean" | "route53";
 
 /**
- * Unified DNS record shape returned by all providers. Each provider's
+ * Unified DNS record shape used across providers. Each provider's
  * native record type (e.g. `DODomainRecord`) is normalized to this shape
  * inside the dispatcher so consumers stay provider-agnostic.
+ *
+ * `description` is an optional human-readable label produced by
+ * `generateDNSRecords()` (e.g. "SES Domain Verification") and consumed
+ * by `formatDNSInstructions()` for the manual-setup output. Providers
+ * that don't surface a description (Route53's UPSERT path) simply
+ * leave it undefined.
  */
 export interface DnsProviderRecord {
   type: string;
   name: string;
   value: string;
   ttl: number;
+  description?: string;
 }
 
 const DEFAULT_PROVIDER: DnsProviderName = "digitalocean";


### PR DESCRIPTION
## 요약
- optional `description?: string` 필드를 `DnsProviderRecord` 로 promote — `digitalocean.ts` 가 이전에 필요로 하던 모든 것을 unified shape 가 커버.
- `digitalocean.ts` 의 로컬 `DNSRecord` interface 제거. `createDNSRecord`, `updateDNSRecord`, `setupDomainDNS`, `formatDNSInstructions` 가 모두 `DnsProviderRecord` 사용.

Closes #13.

## 상세

PR #8 이 의도적 stub 을 남김: `domains.ts` 의 로컬 `DNSRecord` 는 `DnsProviderRecord` 로 통합됐지만 `digitalocean.ts` 의 동명 interface 는 추가 optional `description` 필드 때문에 보존. 가장 깔끔한 해법 — 당시 follow-up 으로 표기됨 — 은 `description?` 를 unified type 으로 promote. `ses.generateDNSRecords()` 가 이미 생산 중 (`\"SES Domain Verification\"`, `\"DKIM Record (...)\"` 등) 이고 `formatDNSInstructions()` 가 manual-setup 출력에 소비. Route53 의 UPSERT 경로는 description 을 surface 하지 않으니 그 필드를 단순히 undefined 로 두면 됨.

본 PR 이후 코드베이스에 DNS record shape 가 정확히 하나만 존재하고, `dns-provider.ts` 의 `import * as digitalocean` 이 더 이상 분기된 타입을 가리지 않음. 순수 refactor — runtime 동작 변경 없음.

## 변경 파일
```
docs/plan/
└── 006-consolidate-dns-record-type.md      # 신규 — 작은 plan
src/lib/
├── dns-provider.ts                          # DnsProviderRecord 에 optional description 필드 추가
└── digitalocean.ts                          # 로컬 DNSRecord 제거, DnsProviderRecord 사용
```

## 커밋
- [`47ece50`](https://github.com/Orchemi/my-resend/commit/47ece50) docs(plan): add 006 DNS record type consolidation plan
- [`702fd0c`](https://github.com/Orchemi/my-resend/commit/702fd0c) refactor(types): consolidate DigitalOcean DNSRecord into DnsProviderRecord

## 테스트 계획
- [x] `npm run lint` — warning/error 0
- [x] `npm test -- --testPathPatterns='src/lib'` — 7 suites / 111 tests 통과 (회귀 0)
- [x] `npm run build` — production build OK; typecheck strict, 모든 라우트 컴파일