### PR TITLE
tsc --noEmit 에러 23 → 0

### DIFF
--- a/docs/plan/007-tsc-error-cleanup.md
+++ b/docs/plan/007-tsc-error-cleanup.md
@@ -1,0 +1,121 @@
+# 007-tsc-error-cleanup
+
+## 개요
+
+- **이슈**: [#15](https://github.com/Orchemi/my-resend/issues/15)
+- **브랜치**: `feat/15`
+- **상태**: 진행 중
+- **생성일**: 2026-04-26
+- **선행**: PR #8 / PR #14 — 두 PR 의 follow-up 노트에서 "사전 존재 tsc 에러 — typing 정리 트랙" 으로 기록됐던 잔여물
+
+## 배경
+
+`npm test` (Jest + ts-jest, transpile-only) 와 `npm run build` (Next.js, 자체 typecheck) 모두 통과하지만, `tsc --noEmit` 으로 strict typecheck 를 돌리면 5 개 테스트 파일에서 **23 개 에러** 가 발생한다.
+
+원인은 다양하다:
+- TypeScript 5+ 의 더 엄격한 타입 정의 (`process.env.NODE_ENV` readonly)
+- jest 의 `MockedFunction` / `MockInstance` 타입 시그니처 변경
+- 함수 시그니처가 단순화 되었지만 테스트 호출이 갱신 안 됨 (`getBestHostedTier()`)
+- ses.ts `generateDNSRecords` 가 explicit return type 없이 inference 에 의존 → DnsProviderRecord 와 미묘한 차이
+- v2 SDK input 타입을 `Record<string, unknown>` 으로 단순 cast 하는 것을 TS5 가 거부 ("convert via unknown first")
+- 테스트 fixture 의 literal 타입이 실제 type 과 미스매치 (`count: '30'` vs `count: number`)
+
+전부 mechanical fix 라 한 PR 안에서 정리.
+
+## 목표
+
+- [ ] 23 개 에러 모두 0 으로
+- [ ] 테스트 suite 무회귀 (128 → 128 pass)
+- [ ] lint clean, build OK
+- [ ] 기존 동작 변경 없음 (순수 타입·테스트 cleanup)
+
+## 설계
+
+### 에러 분류 + 수정 전략
+
+| 파일 | 에러 수 | 원인 | 수정 |
+|------|---------|------|------|
+| `domains-dns-integration.test.ts` | 5 | `generateDNSRecords` inferred return type 가 description 을 required 로 추론 | `ses.ts` 의 `generateDNSRecords` 에 `: DnsProviderRecord[]` annotation 추가 |
+| `ses.test.ts` | 3 | TS5 가 v2 SDK Input → `Record<string, unknown>` 직접 cast 거부 | `as unknown as Record<string, unknown>` 으로 두-단계 변환 |
+| `pricing-calculator.test.ts` | 8 | `getBestHostedTier()` 가 parameterless 인데 테스트가 1 인자 전달 | 8 개 호출에서 인자 제거 |
+| `WaitlistSignup.test.tsx` | 1 | TS5 가 `process.env.NODE_ENV` 를 readonly 로 정의 | `Object.defineProperty` 로 mutable 할당, 또는 mutable cast |
+| `database-waitlist.test.ts` | 6 | jest `MockedFunction` 타입 시그니처 변경 + fixture literal 타입 미스매치 | mock typing 재작성 + `count: '30'` → `count: 30` |
+
+### 변경 범위
+
+```
+my-resend/
+├── src/lib/
+│   └── ses.ts                                          # generateDNSRecords return type annotation
+├── src/lib/__tests__/
+│   ├── ses.test.ts                                     # 3 cast 갱신 (unknown 경유)
+│   ├── pricing-calculator.test.ts                      # 8 호출에서 인자 제거
+│   └── database-waitlist.test.ts                       # mock typing + fixture literal
+├── src/components/__tests__/
+│   └── WaitlistSignup.test.tsx                         # NODE_ENV 할당 방식 변경
+└── docs/plan/
+    └── 007-tsc-error-cleanup.md                        # 본 문서
+```
+
+**무수정**:
+- 본격 src 모듈 (digitalocean, route53, dns-provider, domains, database 본체) — 단 ses.ts 의 1 줄 annotation 추가만
+- 테스트 행동 (assert 결과)
+- 라이브러리 의존성
+
+### 의사결정 기록
+
+| 결정 사항 | 선택지 | 결정 | 이유 |
+|-----------|--------|------|------|
+| `generateDNSRecords` return | A) inference 유지 + 테스트 mock 에 description 채우기 / B) explicit `DnsProviderRecord[]` annotation | **B** | 단일 source 변경으로 5 개 mock site 동시 수정. annotation 은 의도 명시 효과도 있음 |
+| `getBestHostedTier` 인자 처리 | A) 함수에 optional `_volume?: number` 추가 / B) 테스트에서 인자 제거 | **B** | 함수가 정말 parameterless 이고 분기 없음. unused param 추가는 dead 코드 |
+| `NODE_ENV` 할당 | A) `Object.defineProperty` / B) mutable cast / C) `delete env then assign` | **A** | property descriptor 가 가장 명시적. `configurable: true` 로 다음 테스트가 다시 set 가능 |
+| jest mock typing 재작성 깊이 | A) 최소 변경 (타입 cast) / B) 전체 패턴 재작성 | **A** | 본 PR 은 tsc 정리 트랙. 큰 패턴 재작성은 별도 후속 |
+| `tsc --noEmit` CI 통합 | A) 본 PR 에서 / B) 별도 작은 후속 | **B** | 본 PR 의 단위 명확화. CI 통합은 통과 baseline 확보 후 별도 |
+
+## 작업 단계
+
+### Phase 1: ses.ts 1 줄 추가 (5 에러 동시 해결)
+
+- [ ] `import type { DnsProviderRecord } from "./dns-provider";` (이미 없으면)
+- [ ] `generateDNSRecords` 에 `: DnsProviderRecord[]` 명시
+- [ ] tsc 재실행 → 5 에러 사라짐 확인
+
+### Phase 2: ses.test.ts 3 cast (3 에러)
+
+- [ ] 라인 72, 363, 495 의 `as Record<string, unknown>` → `as unknown as Record<string, unknown>`
+
+### Phase 3: pricing-calculator.test.ts 8 호출 (8 에러)
+
+- [ ] 라인 138-148 의 `getBestHostedTier(N)` → `getBestHostedTier()` (8 곳)
+
+### Phase 4: WaitlistSignup.test.tsx (1 에러)
+
+- [ ] `process.env.NODE_ENV = "development"` → `Object.defineProperty(process.env, "NODE_ENV", { value: "development", configurable: true, writable: true })`
+
+### Phase 5: database-waitlist.test.ts (6 에러)
+
+- [ ] mock 타입 정의 재작성 (mockPool / mockClient): jest 5+ 의 `MockedFunction` 시그니처 맞추기
+- [ ] 라인 307, 308, 311, 312 의 `count: '30'` 등 → `count: 30` (number)
+
+### Phase 6: 검증
+
+- [ ] `npx tsc --noEmit` → **0 errors**
+- [ ] `npm run lint` → 0 warnings
+- [ ] `npm test` → 128 pass (회귀 없음)
+- [ ] `npm run build` → success
+
+### Phase 7: 커밋 + PR
+
+- [ ] 2 commits 또는 5 commits (관심사별)
+- [ ] `/pr auto`
+
+## 진행 로그
+
+| 날짜 | 내용 | 비고 |
+|------|------|------|
+| 2026-04-26 | 이슈 #15, `feat/15` 브랜치, 본 plan 작성 | PR #14 직후 후속 |
+
+## 참고
+
+- 직전 plan 006: `docs/plan/006-consolidate-dns-record-type.md`
+- TypeScript 5 NODE_ENV readonly: <https://github.com/microsoft/TypeScript/issues/53083>

--- a/src/components/__tests__/WaitlistSignup.test.tsx
+++ b/src/components/__tests__/WaitlistSignup.test.tsx
@@ -324,8 +324,14 @@ describe("WaitlistSignup Component", () => {
 
   describe("Analytics Tracking", () => {
     beforeEach(() => {
-      // Set NODE_ENV to development for console logging
-      process.env.NODE_ENV = "development";
+      // TypeScript 5+ types `process.env.NODE_ENV` as readonly. Use
+      // defineProperty so the assignment compiles and the value can be
+      // reset between test runs.
+      Object.defineProperty(process.env, "NODE_ENV", {
+        value: "development",
+        configurable: true,
+        writable: true,
+      });
     });
 
     it("tracks form view on mount", () => {

--- a/src/lib/__tests__/database-waitlist.test.ts
+++ b/src/lib/__tests__/database-waitlist.test.ts
@@ -33,9 +33,12 @@ import {
   db,
 } from '../database';
 
-// Get access to the mocked pool
-const mockPool = db as {
-  connect: jest.MockedFunction<() => Promise<{ query: jest.MockedFunction<unknown>; release: jest.MockedFunction<unknown> }>>;
+// Get access to the mocked pool. The actual `Pool` type from `pg` has a
+// dozen methods we don't touch here — narrow to just the surface this
+// test mutates. `jest.Mock` (vs `MockedFunction<...>`) avoids TypeScript's
+// strict callable-shape comparison with the real `Pool.connect` overload.
+const mockPool = db as unknown as {
+  connect: jest.Mock;
 };
 const mockClient = {
   query: jest.fn(),
@@ -304,12 +307,12 @@ describe('Waitlist Database Operations', () => {
         signups_this_month: 45,
         avg_estimated_volume: 15000.5,
         top_referral_sources: [
-          { source: 'google', count: '30' },
-          { source: 'twitter', count: '20' },
+          { source: 'google', count: 30 },
+          { source: 'twitter', count: 20 },
         ],
         top_utm_sources: [
-          { source: 'google', count: '25' },
-          { source: 'facebook', count: '15' },
+          { source: 'google', count: 25 },
+          { source: 'facebook', count: 15 },
         ],
       };
 

--- a/src/lib/__tests__/pricing-calculator.test.ts
+++ b/src/lib/__tests__/pricing-calculator.test.ts
@@ -135,17 +135,14 @@ describe('getMyResendCost', () => {
 
 describe('getBestHostedTier', () => {
   it('should always return the single hosted tier', () => {
-    expect(getBestHostedTier(1000).name).toBe('Hosted');
-    expect(getBestHostedTier(3000).name).toBe('Hosted');
-    expect(getBestHostedTier(5000).name).toBe('Hosted');
-    expect(getBestHostedTier(50000).name).toBe('Hosted');
-    expect(getBestHostedTier(1000000).name).toBe('Hosted');
+    // Function is parameterless — it returns the same tier regardless of
+    // call site. The original tests passed an argument back when the
+    // function took a `volume` parameter.
+    expect(getBestHostedTier().name).toBe('Hosted');
   });
 
-  it('should handle edge cases', () => {
-    expect(getBestHostedTier(0).name).toBe('Hosted');
-    expect(getBestHostedTier(-1000).name).toBe('Hosted');
-    expect(getBestHostedTier(5000000).name).toBe('Hosted');
+  it('should consistently return the same tier instance', () => {
+    expect(getBestHostedTier()).toBe(getBestHostedTier());
   });
 });
 

--- a/src/lib/__tests__/ses.test.ts
+++ b/src/lib/__tests__/ses.test.ts
@@ -69,7 +69,8 @@ describe("createConfigurationSet", () => {
     });
     // Negative assertion: v1-style nested key must NOT be present
     expect(
-      (calls[0].args[0].input as Record<string, unknown>).ConfigurationSet
+      (calls[0].args[0].input as unknown as Record<string, unknown>)
+        .ConfigurationSet
     ).toBeUndefined();
   });
 
@@ -360,7 +361,7 @@ describe("sendEmail (Simple content)", () => {
     });
 
     // v1 keys must NOT leak through
-    const inputAsRecord = input as Record<string, unknown>;
+    const inputAsRecord = input as unknown as Record<string, unknown>;
     expect(inputAsRecord.Source).toBeUndefined();
     expect(inputAsRecord.Message).toBeUndefined();
     expect(inputAsRecord.Tags).toBeUndefined();
@@ -492,7 +493,7 @@ describe("sendRawEmail (Raw content)", () => {
     expect(input.Content?.Simple).toBeUndefined();
 
     // v1-style top-level keys must not leak
-    const inputAsRecord = input as Record<string, unknown>;
+    const inputAsRecord = input as unknown as Record<string, unknown>;
     expect(inputAsRecord.Source).toBeUndefined();
     expect(inputAsRecord.Destinations).toBeUndefined();
     expect(inputAsRecord.RawMessage).toBeUndefined();

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -273,14 +273,25 @@ export async function getWaitlistAnalytics(): Promise<WaitlistAnalytics> {
     ),
   ]);
 
+  // Postgres returns COUNT(*) as a string-typed bigint; parse here so
+  // the returned shape matches WaitlistAnalytics (numeric `count`).
+  const parseCountRows = (
+    rows: Array<{ source: string; count: string | number }>
+  ): Array<{ source: string; count: number }> =>
+    rows.map((row) => ({
+      source: row.source,
+      count:
+        typeof row.count === "number" ? row.count : parseInt(row.count, 10),
+    }));
+
   return {
     total_signups: parseInt(totalResult.rows[0].count),
     signups_today: parseInt(todayResult.rows[0].count),
     signups_this_week: parseInt(weekResult.rows[0].count),
     signups_this_month: parseInt(monthResult.rows[0].count),
     avg_estimated_volume: parseFloat(avgVolumeResult.rows[0].avg_volume) || 0,
-    top_referral_sources: referralSourcesResult.rows,
-    top_utm_sources: utmSourcesResult.rows,
+    top_referral_sources: parseCountRows(referralSourcesResult.rows),
+    top_utm_sources: parseCountRows(utmSourcesResult.rows),
   };
 }
 

--- a/src/lib/ses.ts
+++ b/src/lib/ses.ts
@@ -8,6 +8,7 @@ import {
   CreateConfigurationSetCommand,
   PutEmailIdentityDkimAttributesCommand,
 } from "@aws-sdk/client-sesv2";
+import type { DnsProviderRecord } from "./dns-provider";
 
 /**
  * Build a fresh SESv2 client per call. Mirrors the lazy pattern used in
@@ -312,7 +313,7 @@ export function generateDNSRecords(
   domain: string,
   verificationToken: string,
   dkimTokens: string[] = []
-) {
+): DnsProviderRecord[] {
   const records = [
     {
       type: "TXT",


### PR DESCRIPTION
## 요약
- `tsc --noEmit` 을 5 테스트 파일에 걸친 23 에러에서 **0** 으로. `tsc --noEmit` 을 CI 에 추가하기 위한 prerequisite (별도 작은 follow-up PR).
- 3 commits: 타입 contract 가 위반되던 작은 구현 fix (`getWaitlistAnalytics` 가 nested rows 의 string `count` 를 그대로 반환), 그에 매칭되는 테스트 cleanup, 그리고 테스트 파일들의 mechanical type cleanup 4건.

Closes #15.

## 상세

### `fix(database)`: waitlist analytics rows 의 count string parse

`WaitlistAnalytics.top_referral_sources` 와 `top_utm_sources` 는 `Array<{ source: string; count: number }>` 로 타입되어 있지만 Postgres 가 `COUNT(*)` 를 string-typed bigint 로 반환하고 구현은 rows 를 unchanged 로 통과시켰음. loose `query()` typing 이 이 위반을 가렸음. `parseCountRows` 헬퍼를 추가해 각 row 를 `parseInt` 로 매핑하고, 테스트 fixture 도 numeric literal 로 갱신 (이제 정직해진 타입에 매칭). `Pool` mock 도 `unknown` cast 통한 plain `jest.Mock` 으로 loosen — strict `MockedFunction` generic 이 TypeScript 5+ 의 `pg` overloaded `Pool.connect` 와 호환 불가.

### `refactor(types)`: 테스트 인프라의 나머지 tsc 에러 정리

mechanical fix 4건:

- **`generateDNSRecords` return annotation** (`src/lib/ses.ts`): inferred return type 가 `description` 을 required 로 만듦 (모든 literal 이 set), 이 때문에 integration 테스트의 mock — 의도적으로 `description` 생략 — 이 tsc fail. 명시적 `: DnsProviderRecord[]` annotation 으로 optional 로 widen 하여 5 에러 동시 제거.
- **SDK Input cast** (`src/lib/__tests__/ses.test.ts`): SDK input 타입을 `Record<string, unknown>` 으로 narrow 할 때 `unknown` 경유 cast. TypeScript 5+ 가 직접 변환을 잠재적 unsafe 로 거부.
- **`getBestHostedTier` 테스트 호출** (`src/lib/__tests__/pricing-calculator.test.ts`): 8 호출처에서 unused 인자 제거. 함수가 이제 parameterless; 원래 테스트는 함수가 `volume` 파라미터를 받던 시점에 작성됨.
- **`process.env.NODE_ENV` 할당** (`src/components/__tests__/WaitlistSignup.test.tsx`): `Object.defineProperty` 사용하여 컴파일 통과. TypeScript 5+ 가 그 속성을 readonly 로 표기.

non-test 호출자에게 행동 변경 없음. `parseCountRows` 구현 변경은 runtime 데이터를 declared 타입에 매칭 — 이전엔 타입이 row shape 에 대해 거짓말 중.

## 변경 파일
```
docs/plan/
└── 007-tsc-error-cleanup.md                            # 신규 — cleanup 기록 plan
src/lib/
├── database.ts                                          # waitlist analytics 의 parseCountRows
├── ses.ts                                               # 명시적 DnsProviderRecord[] return type
└── __tests__/
    ├── database-waitlist.test.ts                        # numeric count fixture + Pool mock typing
    ├── pricing-calculator.test.ts                       # getBestHostedTier 인자 제거
    └── ses.test.ts                                      # SDK Input narrowing 위해 unknown 경유 cast
src/components/__tests__/
└── WaitlistSignup.test.tsx                              # NODE_ENV 에 Object.defineProperty
```

## 커밋
- [`8eafaf2`](https://github.com/Orchemi/my-resend/commit/8eafaf2) docs(plan): add 007 tsc error cleanup plan
- [`a5a9320`](https://github.com/Orchemi/my-resend/commit/a5a9320) fix(database): parse count strings in waitlist analytics rows
- [`9ce8a1f`](https://github.com/Orchemi/my-resend/commit/9ce8a1f) refactor(types): clean up remaining tsc errors in test infrastructure

## 테스트 계획
- [x] `npx tsc --noEmit` — **에러 0** (이전 23)
- [x] `npm run lint` — warning/error 0
- [x] `npm test -- --testPathPatterns='src/lib' --runInBand` — 7 suites / 111 tests 통과
- [x] `npm run build` — production build OK; typecheck strict, 모든 라우트 컴파일
- [x] `WaitlistSignup` 테스트 실행 (suite 가 본 환경에서 parallel 실행 시 알려진 baseline jest-worker SIGABRT 보유; in-band 실행은 exit code 0 으로 완료)

## 본 PR 범위 밖 (별도 PR)
- `typecheck` npm 스크립트와 CI 파이프라인에 `tsc --noEmit` 추가
- WaitlistSignup jest-worker SIGABRT (parallel 실행 시) 환경 조사 — 환경/heap 이슈, 테스트 로직 아님
- Cloudflare DNS provider