### PR TITLE
feat(admin): add Connections tab health check for SES + DNS env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,13 @@ The schema lives in `database.sql`; there is no migration framework — apply on
 - bcrypt hashing with the `mrs_` prefix preserved for identification
 - Domain-scoped permissions
 
+**Admin Connections Health** (`src/app/api/health/{ses,dns}/route.ts` + `src/components/ConnectionsTab.tsx`):
+- Two read-only admin endpoints (`GET /api/health/ses`, `GET /api/health/dns`) protected by inline JWT verification (matching the `auth/me` and `domains` routes)
+- SES probe: single `GetAccountCommand`, returns `{ ok, region, sandbox, sendingEnabled, enforcementStatus, sendQuota }`. `ok: true|false` both serialize as HTTP 200 so the dashboard handles a single result path
+- DNS probe: dispatches via `checkDnsProvider()` to the active provider's `checkProvider()` — DigitalOcean lists `/v2/domains`, Route53 either reads the pinned zone (`AWS_HOSTED_ZONE_ID`) via `GetHostedZoneCommand` or lists account zones via `ListHostedZonesCommand`
+- Secret policy: errors are reduced to a `{ name, message, httpStatusCode }` whitelist before serialization; AWS access keys, DO API tokens, JWTs are never reflected. Tested via regex-based sanity assertions in every route + component test
+- Dashboard surface: a Connections tab fires both fetches in parallel on mount and re-runs them on Refresh (no automatic polling — operator-initiated only)
+
 ## API Design Patterns
 
 ### Resend Compatibility

--- a/README.ko.md
+++ b/README.ko.md
@@ -17,6 +17,7 @@ my-resend 는 [eibrahim/freeresend](https://github.com/eibrahim/freeresend) (MIT
 - 📊 **발송 로그** — 모든 발송 건의 전달 상태와 webhook 이벤트 추적
 - 🎯 **도메인 verify** — SES 도메인 인증 자동화 + 멱등 재시도
 - 🔒 **보안** — JWT 기반 대시보드 인증, bcrypt 비밀번호 해싱, 매개변수화 SQL
+- 🩺 **연결 헬스 체크** — 어드민 전용 `Connections` 탭으로 Amazon SES (sandbox 여부, 송신 quota) 와 활성 DNS provider 를 한 번에 진단; read-only, 시크릿 미노출
 - 🐳 **컨테이너 친화적** — Dockerfile 포함; Docker / Dokku / Coolify / Fly.io / Kubernetes 등 Node.js 장기 실행 프로세스를 지원하는 모든 호스트에서 동작
 - 🧪 **테스트** — Jest 단위 + 통합 테스트로 SES, DNS provider, Route53 surface 검증 (`aws-sdk-client-mock` 사용, CI 에서 라이브 AWS 호출 없음)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ my-resend is a hard fork of [eibrahim/freeresend](https://github.com/eibrahim/fr
 - 📊 **Email logging** — every send tracked with delivery status and webhook events
 - 🎯 **Domain verification** — automated SES domain verification with idempotent retries
 - 🔒 **Secure** — JWT-based dashboard auth, bcrypt password hashing, parameterised SQL
+- 🩺 **Connections health** — admin-only `Connections` tab probes Amazon SES (sandbox flag, send quota) and the active DNS provider in one click; read-only, secret-free responses
 - 🐳 **Container-friendly** — Dockerfile included; runs on Docker, Dokku, Coolify, Fly.io, Kubernetes, or any host that runs a long-lived Node.js process
 - 🧪 **Tested** — Jest unit + integration suite covering the SES, DNS provider, and Route53 surfaces using `aws-sdk-client-mock` (no live AWS calls in CI)
 

--- a/docs/plan/009-admin-connections-health-check.md
+++ b/docs/plan/009-admin-connections-health-check.md
@@ -1,0 +1,340 @@
+# 009-admin-connections-health-check
+
+## 개요
+
+- **이슈**: [#22](https://github.com/Orchemi/my-resend/issues/22)
+- **브랜치**: `feat/22`
+- **상태**: 진행 중
+- **생성일**: 2026-04-27
+- **선행**: [PR #18](https://github.com/Orchemi/my-resend/pull/18) — CI gate (plan 008). 본 PR 도 동일한 4 단계 (lint → typecheck → test → build) 를 머지 기준으로 그대로 사용한다.
+
+## 배경
+
+운영자가 SES / DNS provider 환경변수 (`AWS_*`, `DO_API_TOKEN`, `AWS_HOSTED_ZONE_ID`, `DNS_PROVIDER`) 를 설정한 뒤 "정말 정상 동작 가능한 상태인가?" 를 확인할 비파괴 경로가 없다. 현재 검증 방법은 "도메인 추가 → DNS 레코드 생성 → 검증 메일 발송" 까지 끝까지 가야 하는데, 그 전에 단순 credential / IAM 권한 누락이면 한참 후에야 실패가 드러난다.
+
+Admin Dashboard 에 **Connections** 탭을 추가해 SES 와 활성 DNS provider 의 헬스를 한 번의 fetch 로 확인할 수 있게 한다. 호출은 모두 read-only — 도메인을 만들거나 메시지를 보내지 않는다. 응답에는 region 같은 비시크릿 진단 정보만 포함하고, AWS access key / DO token 같은 시크릿은 어떤 경로로도 노출되지 않는다.
+
+upstream `freeresend` 에는 admin 헬스 체크 개념이 없었으므로 본 작업은 fork 의 추가 기능이다.
+
+## 목표
+
+- [x] `GET /api/health/ses` — SESv2 GetAccount 기반 헬스 + 송신 quota 응답 (admin only)
+- [x] `GET /api/health/dns` — 활성 DNS provider 의 헬스 응답 (admin only, provider dispatch)
+- [x] `src/lib/dns-provider.ts` 에 `checkDnsProvider()` 디스패처 + 각 provider 모듈에 `checkProvider()` 추가
+- [x] `src/components/ConnectionsTab.tsx` — 카드 2 개 (SES, DNS) + refresh 버튼
+- [x] `src/components/Dashboard.tsx` 에 `connections` 탭 등록 (Tab union, tabs 배열, 렌더 분기)
+- [x] 양 route + DNS provider check 함수 + ConnectionsTab 컴포넌트 단위 테스트 추가
+- [x] CLAUDE.md / README 에 Connections 탭 한 단락 추가
+- [x] 로컬 4 단계 (`npm run lint` → `npm run typecheck` → `npm test -- --runInBand` → `npm run build`) 모두 통과 확인
+
+## 설계
+
+### 접근 방식
+
+1. **read-only 헬스**. 모든 호출은 list / get 계열만 사용한다 — `SESv2.GetAccount`, DO `GET /v2/domains`, Route53 `ListHostedZones` 또는 `GetHostedZone`. 도메인 생성 / 레코드 변경 / 메시지 발송은 절대 일어나지 않는다.
+2. **active provider 만 확인**. `getDnsProviderName()` 의 결과로 현재 활성인 한쪽만 체크한다. 두 provider 동시 probing 은 불필요하고, 비활성 provider 의 토큰 부재를 false-negative 로 보고하게 된다. 이슈 본문의 "isolation" 은 **단위 테스트 단위에서 두 provider 가 서로 영향을 주지 않게 격리** 한다는 뜻으로 해석한다 (각각의 mock 셋업이 분리됨).
+3. **어드민 전용**. 두 route 모두 기존 `withAuth` middleware 로 감싼다. JWT 미보유 / 만료 시 401 — middleware 가 일관 처리. role 기반 추가 분기는 본 PR 의 단위 밖.
+4. **비시크릿만 응답**. 응답에 region 등 운영 진단에 쓸 수 있는 비밀이 아닌 정보만 포함한다. `accessKeyId`, `secretAccessKey`, DO token, JWT, 또는 raw `error.stack` 은 어떤 분기에서도 직렬화하지 않는다. AWS / axios 에러는 `{ name, message, httpStatusCode }` 의 좁은 정규화 객체로 바뀌어 `error` 필드에 들어간다.
+5. **마운트 1 회 + 수동 refresh**. ConnectionsTab 은 mount 시 두 fetch 를 동시 실행하고, refresh 버튼으로 재실행한다. 자동 polling 은 본 PR 의 단위 밖 — "후속 트랙 후보" 로 기록.
+
+### API 응답 스키마
+
+`GET /api/health/ses` (SESv2.GetAccount 1 콜):
+
+```ts
+type SesHealthResponse =
+  | {
+      ok: true;
+      region: string;                  // process.env.AWS_REGION || "us-east-1"
+      sandbox: boolean;                // !response.ProductionAccessEnabled
+      sendingEnabled: boolean;         // response.SendingEnabled
+      enforcementStatus: string | null; // response.EnforcementStatus (e.g. "HEALTHY")
+      sendQuota: {
+        max24HourSend: number;         // response.SendQuota.Max24HourSend
+        maxSendRate: number;           // response.SendQuota.MaxSendRate
+        sentLast24Hours: number;       // response.SendQuota.SentLast24Hours
+      } | null;                        // null if SendQuota absent (e.g. some sandbox accounts)
+    }
+  | {
+      ok: false;
+      region: string;
+      error: { name: string; message: string; httpStatusCode: number | null };
+    };
+```
+
+`GET /api/health/dns`:
+
+```ts
+type DnsHealthResponse =
+  | {
+      ok: true;
+      provider: "digitalocean";
+      detail: { domainCount: number };
+    }
+  | {
+      ok: true;
+      provider: "route53";
+      detail: { hostedZoneCount: number; pinnedZoneId: string | null };
+    }
+  | {
+      ok: false;
+      provider: "digitalocean" | "route53";
+      error: { name: string; message: string; httpStatusCode: number | null };
+    };
+```
+
+### SES 헬스 — `GetAccountCommand` 단일 호출
+
+`@aws-sdk/client-sesv2` 의 `GetAccountCommand` 응답에 다음 필드가 모두 들어 있다 (AWS SDK v3 sesv2 공식 API):
+
+- `SendQuota`: `{ Max24HourSend, MaxSendRate, SentLast24Hours }`
+- `ProductionAccessEnabled`: boolean — `false` ↔ sandbox
+- `SendingEnabled`: boolean — 계정 송신 가능 여부
+- `EnforcementStatus`: `"HEALTHY" | "PROBATION" | "SHUTDOWN"` 등
+
+따라서 quota 와 sandbox 판정 모두 sesv2 SDK 한 콜로 충족 — `@aws-sdk/client-ses` v1 SDK 추가 불필요. `sandbox = !ProductionAccessEnabled` 로 판단한다. `SendingEnabled` 와 `EnforcementStatus` 는 별개 질문에 대한 답이라 (각각 "지금 보낼 수 있나?" / "어카운트가 sandbox 인가?") 분리해서 응답에 노출한다.
+
+> 구현 시점에 SDK 응답 shape 가 위와 다르면 (`SendQuota` 누락 등) `@aws-sdk/client-ses` v1 의 `GetSendQuotaCommand` 추가를 fallback 으로 검토. 그 경우 `package.json` 에 의존성 1 개 추가, 같은 region / credential 로 두 client 모두 빌드.
+
+### DNS 헬스 — provider 디스패처
+
+`src/lib/dns-provider.ts` 에 검사 함수 추가:
+
+```ts
+export type DnsHealth =
+  | { ok: true; provider: "digitalocean"; detail: { domainCount: number } }
+  | { ok: true; provider: "route53"; detail: { hostedZoneCount: number; pinnedZoneId: string | null } }
+  | { ok: false; provider: DnsProviderName; error: { name: string; message: string; httpStatusCode: number | null } };
+
+export async function checkDnsProvider(): Promise<DnsHealth> {
+  const provider = getDnsProviderName();
+  switch (provider) {
+    case "digitalocean": return digitalocean.checkProvider();
+    case "route53":      return route53.checkProvider();
+  }
+}
+```
+
+각 provider 의 `checkProvider()`:
+
+- **`digitalocean.checkProvider()`**: `getApiToken()` 부재 → `{ ok: false, error: { name: "MissingToken", message: "DO_API_TOKEN is not set", httpStatusCode: null } }`. 토큰 있으면 기존 `getDomains()` 호출 → `{ ok: true, detail: { domainCount: domains.length } }`. axios 에러는 `{ name: error.name ?? "AxiosError", message: error.message, httpStatusCode: error.response?.status ?? null }` 로 정규화.
+- **`route53.checkProvider()`**: `AWS_HOSTED_ZONE_ID` 가 설정돼 있으면 `GetHostedZoneCommand({ Id })` 호출 → 성공 시 `{ ok: true, detail: { hostedZoneCount: 1, pinnedZoneId } }`. 미설정이면 `ListHostedZonesCommand({})` 로 계정 단위 zone 목록 조회 → `{ ok: true, detail: { hostedZoneCount: response.HostedZones?.length ?? 0, pinnedZoneId: null } }`. AWS 에러는 `{ name, message, httpStatusCode: error.$metadata?.httpStatusCode ?? null }`.
+
+> 부분 성공 (예: list 는 되는데 일부 zone 만 권한 없음) 케이스는 본 헬스의 단위 밖이다 — list 가 200 으로 돌아오면 `ok: true`, 권한 부족이면 list 자체가 401/403 으로 떨어져 `ok: false` 가 된다.
+
+### Route 파일 패턴 (Next.js 15 App Router)
+
+기존 `src/app/api/auth/me/route.ts` 등의 컨벤션:
+
+```ts
+export const GET = withAuth(async (_req) => {
+  try {
+    const result = await ...;
+    return NextResponse.json(result);
+  } catch (error: unknown) {
+    return NextResponse.json(normalize(error), { status: 200 });
+    // 또는 5xx 가 의미 있으면 status 분기. 본 헬스는 "체크 자체가 실패해도
+    // 진단 정보를 200 으로 돌려준다" 정책: ok=false 가 정상 응답이며,
+    // 라우트 자체가 throw 한 경우만 500.
+  }
+});
+```
+
+응답 status 정책:
+
+- `ok: true` / `ok: false` 둘 다 **HTTP 200** — UI 가 한 fetch 로 result 를 처리할 수 있게.
+- 라우트 핸들러 내부에서 예기치 못한 throw (정규화 실패 등) → 500, body 는 `handleError()` 의 표준 포맷.
+
+### UI — `ConnectionsTab.tsx`
+
+- 기존 `[Feature]Tab.tsx` 패턴 + Tailwind v4. `'use client'`.
+- 카드 2 개 (SES, DNS), 각 카드 우상단에 상태 뱃지: `loading` (gray) / `ok` (green) / `error` (red).
+- mount 시 `useEffect` 로 두 endpoint 를 `Promise.all` 로 동시 fetch.
+- "Refresh" 버튼: 로딩 중 disabled, 클릭 시 동일 fetch 재실행.
+- SES 카드: region, sandbox 여부, sendingEnabled, enforcementStatus, sendQuota 3 필드를 표 형태로. 에러면 `error.name` + `error.message` 만 표시.
+- DNS 카드: provider 이름, provider 별 detail (DO=domainCount, Route53=hostedZoneCount + pinnedZoneId 있으면 표시). 에러면 동일.
+- 시크릿 일체 미표시. region / provider 이름 / count 만.
+
+### Dashboard 통합
+
+```ts
+type Tab = "domains" | "apikeys" | "logs" | "connections";
+
+const tabs = [
+  ...,
+  { id: "connections" as Tab, name: "Connections", description: "SES & DNS provider health" },
+];
+
+{activeTab === "connections" && <ConnectionsTab />}
+```
+
+탭 순서는 도메인 / API Keys / Logs / Connections — 일상 사용도가 낮으므로 끝에 배치.
+
+### 변경 범위
+
+```
+my-resend/
+├── src/lib/
+│   ├── dns-provider.ts                           # checkDnsProvider() + DnsHealth 타입 추가
+│   ├── digitalocean.ts                           # checkProvider() 추가
+│   └── route53.ts                                # checkProvider() 추가
+├── src/app/api/health/
+│   ├── ses/
+│   │   ├── route.ts                              # 신규 — withAuth(GET)
+│   │   └── __tests__/route.test.ts               # 신규
+│   └── dns/
+│       ├── route.ts                              # 신규 — withAuth(GET)
+│       └── __tests__/route.test.ts               # 신규
+├── src/components/
+│   ├── ConnectionsTab.tsx                        # 신규
+│   ├── Dashboard.tsx                             # Tab union + tabs[] + 렌더 분기
+│   └── __tests__/ConnectionsTab.test.tsx         # 신규
+├── src/lib/__tests__/
+│   ├── digitalocean.test.ts                      # checkProvider 케이스 (없으면 신규 파일)
+│   ├── route53.test.ts                           # checkProvider 케이스 추가
+│   └── dns-provider.test.ts                      # checkDnsProvider 디스패치 케이스 추가
+├── CLAUDE.md                                     # Connections 탭 한 단락 (Architecture 또는 Features 섹션)
+├── README.md / README.ko.md                      # Connections 탭 한 줄 (선택, 필요 시)
+└── docs/plan/
+    └── 009-admin-connections-health-check.md     # 본 문서
+```
+
+**무수정**:
+
+- `src/app/api/health/route.ts` — 기존 정적 health (uptime / version) 는 unauthenticated 라 그대로 둠. SES / DNS 헬스는 별도 path 로 분리.
+- `database.sql` (스키마 변경 없음)
+- 기존 `domains.ts`, `ses.ts` 본체
+
+### 의사결정 기록
+
+| 결정 사항 | 선택지 | 결정 | 이유 |
+|-----------|--------|------|------|
+| SES quota / sandbox 정보원 | A) sesv2 `GetAccountCommand` / B) v1 `GetSendQuotaCommand` 추가 / C) sandbox 판정만 + quota 생략 | **A** | sesv2 GetAccount 응답에 SendQuota / ProductionAccessEnabled / SendingEnabled / EnforcementStatus 모두 포함 — 1 콜로 충분. 의존성 미증가. SDK shape 가 다르면 impl 시점에 B 로 전환 |
+| Sandbox 판정 필드 | A) `!ProductionAccessEnabled` / B) `EnforcementStatus` 파싱 | **A** | ProductionAccessEnabled 가 sandbox 의 정의. EnforcementStatus 는 별개 (probation / shutdown 등) — 둘 다 분리 노출 |
+| DNS health 디스패치 | A) active provider 만 / B) 두 provider 모두 동시 probe | **A** | 비활성 provider 의 토큰 부재가 false-negative 로 보고됨. 이슈 본문 "isolation" 은 단위 테스트 격리 의미로 해석 |
+| Route53 zone 조회 방법 | A) pinnedZoneId 있으면 GetHostedZone, 없으면 ListHostedZones / B) 항상 ListHostedZones | **A** | pinned zone 이 명시돼 있으면 그 zone 의 실제 가시성을 검증하는 게 더 정확. unpinned 면 list 로 전체 가시성 확인 |
+| Auth | A) `withAuth` (JWT) / B) admin role 별도 / C) unauth | **A** | 현 코드베이스에 role 분기 없음 — 향후 role 도입 시 별도 PR. unauth 는 시크릿 에러 메시지 누설 위험 |
+| Auth wiring 형태 | A) `export const GET = withAuth(...)` / B) `export async function GET(req) { ... verifyJWT inline ... }` | **B** | 빌드 시 Next.js 15 의 route export validator 가 `withAuth` 의 generic 두번째 인자를 invalid 로 거부 (`RouteContext<...> \| undefined` ≠ `RouteContext`). 기존 모든 route (`auth/me`, `domains`, `emails/logs` 등) 도 inline 패턴이라 일관성도 보존. middleware 시그니처 수정은 본 PR 단위 밖 — 별도 리팩토링 후속 트랙 후보로 기록 |
+| 응답 status code | A) 항상 200 (ok 필드로 분기) / B) ok=false 시 503 | **A** | UI 가 단일 success path 로 result 처리. 503 은 fetch 가 throw 로 분기돼 UX 가 두 갈래 |
+| Polling | A) mount 1 회 + 수동 refresh / B) 자동 polling | **A** | "후속 트랙 후보" 로 기록. MVP 는 진단 도구 — 운영자가 명시적으로 누를 때만 호출 |
+| 시크릿 노출 정책 | A) region / count 만 / B) AWS account ID 같은 식별자도 포함 | **A** | 본 PR 의 단일 커밋가능 정책. account ID 같은 메타는 가치보다 위험이 큼 |
+
+### 테스트 계획
+
+**`/api/health/ses` route**:
+
+- happy: `aws-sdk-client-mock` 으로 GetAccount 가 `ProductionAccessEnabled: true, SendingEnabled: true, SendQuota: { Max24HourSend: 50000, MaxSendRate: 14, SentLast24Hours: 200 }, EnforcementStatus: "HEALTHY"` 반환 → 응답 `ok: true, sandbox: false, sendQuota: {...}` 검증.
+- sandbox: `ProductionAccessEnabled: false` → `sandbox: true`.
+- IAM 거부: `Object.assign(new Error("not authorized"), { name: "AccessDeniedException", $metadata: { httpStatusCode: 403 } })` reject → `ok: false, error.httpStatusCode: 403`. 시크릿 미포함 검증 (응답 직렬화 결과에 access key / token 패턴 absent).
+- network 에러: `Error("ECONNREFUSED")` reject → `ok: false`.
+- SendQuota 누락: `ProductionAccessEnabled: true, SendQuota: undefined` → `sendQuota: null` (sandbox 계정 일부에서 발생 가능).
+- auth 미통과: `withAuth` 가 401 — middleware 단위라 별도 케이스 1 개로만 검증.
+
+**`/api/health/dns` route** (양 provider 격리):
+
+- DigitalOcean active + 토큰 있음 + `getDomains()` happy → `provider: "digitalocean", detail.domainCount`.
+- DigitalOcean active + 토큰 없음 → `ok: false, error.name: "MissingToken"`.
+- DigitalOcean active + axios 401 → `ok: false, error.httpStatusCode: 401`.
+- Route53 active + `AWS_HOSTED_ZONE_ID` 설정 + GetHostedZone 성공 → `ok: true, detail.hostedZoneCount: 1, detail.pinnedZoneId`.
+- Route53 active + zone id 미설정 + ListHostedZones 응답 (3 zones) → `hostedZoneCount: 3, pinnedZoneId: null`.
+- Route53 active + AWS 403 → `ok: false`.
+- 알 수 없는 `DNS_PROVIDER` → `getDnsProviderName()` 이 throw → 라우트가 500 (`handleError`).
+- 양 케이스에서 `DNS_PROVIDER` 환경변수는 케이스 셋업에서 set, afterEach 에서 원복 (route53.test.ts 의 `ORIGINAL_HOSTED_ZONE_ID` 패턴 따라 격리).
+
+**`ConnectionsTab` 컴포넌트**:
+
+- 마운트 시 두 endpoint fetch 호출 검증 (`global.fetch` mock).
+- 로딩 상태 → ok 전환 → 카드별 데이터 렌더 (region, sandbox, sendQuota, provider, count).
+- 한쪽 fetch reject → 해당 카드만 error 뱃지, 다른 카드는 ok.
+- refresh 버튼 click → fetch 재호출 (call count +2).
+- 응답 텍스트에 시크릿 키 패턴 (e.g. `AKIA`, `Bearer`) 미포함 — sanity assertion.
+
+### 리스크 / 대안
+
+- **SDK shape drift**: sesv2 `GetAccountCommand` 응답이 SDK 마이너 버전에서 필드명 변경 가능성. impl 시점에 실제 응답 타입을 확인하고 (`GetAccountCommandOutput` 타입 import), 차이가 있으면 의사결정 기록을 갱신.
+- **시크릿 누설**: AWS / axios 에러 객체에 `request.headers.Authorization` 가 포함된 경우가 있다. 정규화 단계에서 **whitelist** (`name`, `message`, `httpStatusCode` 만) 로 빌드 — `JSON.stringify(error)` 같은 광범위 직렬화 금지.
+- **Route53 권한 부분 성공**: List 는 200 인데 GetHostedZone 이 일부만 통과하는 경우는 본 헬스의 단위 밖 — list 결과만 신뢰. 향후 도메인별 verification status 통합 시 처리.
+- **DigitalOcean rate limit**: `getDomains()` 가 `retryRequest` 로 감싸져 429 에 백오프. 헬스 체크가 retry 로 길어질 수 있으나 운영자가 누르는 호출이라 허용.
+- **OSS 가시성 (project profile)**: 응답 / 에러 메시지 / 테스트 fixture 에서 horbis, .claude.local, claude code, 개인 도메인 (huns.site 등) 언급 금지. 테스트 fixture 도메인은 RFC 2606 의 `example.com`.
+
+### 머지 기준
+
+- CI gate 4 단계 (lint / typecheck / test / build) 모두 통과 (PR #18 기준).
+- 모든 외부 SDK / HTTP 호출 mock — 실제 AWS / DO 엔드포인트 hit 0.
+- 양 DNS provider 의 check 단위 테스트가 서로의 mock 셋업에 영향받지 않음 (isolation).
+- 응답 직렬화 결과에 시크릿 패턴 (`AKIA*`, `Bearer *`, `secretAccessKey`, `DO_API_TOKEN`) 미포함 — assertion 으로 강제.
+
+### 후속 트랙 후보
+
+- 주기적 polling (e.g. 30s) + 상태 변화 알림.
+- 다른 의존성 헬스: Postgres connection, JWT secret presence.
+- 도메인별 SES verification status 통합 (현 `getDomainVerificationStatus` 활용).
+- Admin role 도입 후 `withAuth` → `withAdminAuth` 로 좁히기.
+- `src/lib/middleware.ts` 의 `withAuth` 시그니처를 Next.js 15 route handler 타입과 호환되도록 리팩토링 (`export const GET = withAuth(...)` 형태가 가능하게). 본 PR 은 빌드 통과를 위해 inline `verifyJWT` 패턴으로 진행 (기존 라우트와 일관 유지).
+
+## 작업 단계
+
+### Phase 1: SES 헬스 route + 테스트
+
+- [x] `src/app/api/health/ses/route.ts` 작성 — `withAuth(async (_req) => ...)`, sesv2 client 빌드, `GetAccountCommand` send, 응답 정규화
+- [x] `src/app/api/health/ses/__tests__/route.test.ts` 작성 — happy / sandbox / IAM 거부 / network 에러 / SendQuota 누락 / auth 누락 케이스 (failing first)
+- [x] 로컬 `npm test -- --runInBand src/app/api/health/ses` 통과
+
+### Phase 2: DNS provider check 함수 + 테스트
+
+- [x] `src/lib/digitalocean.ts` 에 `checkProvider()` 추가
+- [x] `src/lib/route53.ts` 에 `checkProvider()` 추가 (pinned vs list 분기)
+- [x] `src/lib/dns-provider.ts` 에 `DnsHealth` 타입 + `checkDnsProvider()` 디스패처 추가
+- [x] `src/lib/__tests__/digitalocean.test.ts` (없으면 신규) — 토큰 없음 / happy / 401 케이스
+- [x] `src/lib/__tests__/route53.test.ts` 에 checkProvider 케이스 추가 (pinned + GetHostedZone, unpinned + ListHostedZones, 403)
+- [x] `src/lib/__tests__/dns-provider.test.ts` 에 디스패처 케이스 추가
+- [x] 로컬 lib 테스트 통과
+
+### Phase 3: DNS 헬스 route + 테스트
+
+- [x] `src/app/api/health/dns/route.ts` 작성 — `withAuth` + `checkDnsProvider()` 호출 + try/catch (500 분기)
+- [x] `src/app/api/health/dns/__tests__/route.test.ts` 작성 — DO active 3 케이스 / Route53 active 3 케이스 / 알 수 없는 provider 케이스
+- [x] 로컬 통과
+
+### Phase 4: ConnectionsTab + Dashboard 통합
+
+- [x] `src/components/ConnectionsTab.tsx` 작성 — 카드 2 개, mount fetch, refresh 버튼, 상태 뱃지
+- [x] `src/components/__tests__/ConnectionsTab.test.tsx` 작성 — 로딩 / ok / 에러 / refresh / 시크릿 부재 sanity
+- [x] `src/components/Dashboard.tsx` 수정 — Tab union 확장, tabs 배열에 항목 추가, 렌더 분기 추가
+- [x] 로컬 컴포넌트 테스트 통과
+
+### Phase 5: 문서 갱신
+
+- [x] CLAUDE.md 의 Architecture 또는 Features 섹션에 Connections 탭 한 단락 추가 (응답 schema, secret policy, route path)
+- [x] README.md / README.ko.md 의 Features 섹션에 한 줄 추가 (선택)
+
+### Phase 6: CI gate 4 단 로컬 검증
+
+- [x] `npm run lint` → 0 warning
+- [x] `npm run typecheck` → 0 error (PR #16 baseline 유지)
+- [x] `npm test -- --runInBand` → 회귀 없음, 신규 케이스 모두 pass (CI 와 동일하게 `--testPathIgnorePatterns='WaitlistSignup'` 적용 — 이슈 #19 leak 해결 전까지 CI 도 같은 ignore 사용)
+- [x] `npm run build` → success
+
+### Phase 7: 커밋 + PR
+
+- [ ] 관심사별 commit 분리 (feat(health-ses) / feat(dns-provider) / feat(health-dns) / feat(connections-tab) / docs)
+- [ ] `/pr` 으로 PR 생성, base = develop
+- [ ] PR 본문에 응답 schema 예시 + secret policy 명시 + 후속 트랙 후보 follow-up 노트
+
+## 진행 로그
+
+| 날짜 | 내용 | 비고 |
+|------|------|------|
+| 2026-04-27 | 이슈 #22, `feat/22` 브랜치, 본 plan 작성 | PR #18 (CI gate) 직후 |
+| 2026-04-27 | SDK shape 검증: `GetAccountCommandOutput` 의 `SendQuota.Max24HourSend / MaxSendRate / SentLast24Hours`, `ProductionAccessEnabled`, `SendingEnabled`, `EnforcementStatus` 모두 plan 가정과 일치 | `@aws-sdk/client-sesv2@3.1037.0` `dist-types/commands/GetAccountCommand.d.ts` 직접 확인. v1 fallback 불필요 |
+| 2026-04-27 | Phase 1~6 구현 완료, 4단 로컬 통과 (lint 0 warning, tsc 0 error, 14 suites/162 tests, build success) | 신규 28 케이스: SES route 6 + DNS route 8 + Route53 checkProvider 3 + DigitalOcean checkProvider 3 + dns-provider 디스패처 3 + ConnectionsTab 5. Phase 7 (커밋/PR) 은 사용자 명령 대기 |
+| 2026-04-27 | 의사결정 변경: Auth wiring 을 `withAuth(GET)` 에서 inline `verifyJWT` 로 전환 — Next.js 15 의 route export validator 가 `withAuth` generic 시그니처를 invalid 로 거부 (build 단계). 기존 모든 route 가 inline 패턴이라 일관성도 회복. middleware 리팩토링은 후속 트랙 후보로 기록 | "의사결정 기록" 표 + "후속 트랙 후보" 섹션 갱신 |
+
+## 참고
+
+- 직전 plan 008: `docs/plan/008-ci-gate.md`
+- AWS SDK v3 sesv2 GetAccount: <https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sesv2/command/GetAccountCommand/>
+- AWS SDK v3 Route53 ListHostedZones: <https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/route-53/command/ListHostedZonesCommand/>
+- aws-sdk-client-mock: <https://github.com/m-radzikowski/aws-sdk-client-mock>
+- 기존 헬스 패턴: `src/app/api/health/route.ts` (정적 unauthenticated)
+- 기존 라우트 + 인증 패턴: `src/app/api/auth/me/route.ts`, `src/app/api/domains/route.ts`

--- a/src/app/api/health/dns/__tests__/route.test.ts
+++ b/src/app/api/health/dns/__tests__/route.test.ts
@@ -1,0 +1,252 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for src/app/api/health/dns/route.ts (admin DNS provider
+ * health probe).
+ *
+ * Strategy:
+ *   - The DNS provider abstraction is mocked so each case can drive the
+ *     route into a specific provider + health-state branch without
+ *     coupling to the underlying axios / aws-sdk transports.
+ *   - The auth middleware is mocked the same way as the SES route test
+ *     to avoid pulling the api-keys -> nanoid ESM chain into the
+ *     `node` test environment.
+ *   - Env isolation: DNS_PROVIDER and AWS_HOSTED_ZONE_ID are
+ *     setup/teardown per case (route53.test.ts pattern).
+ *   - Every assertion runs the response body through a secret-pattern
+ *     sanity check.
+ */
+import { NextRequest } from "next/server";
+
+jest.mock("../../../../../lib/auth", () => ({
+  __esModule: true,
+  verifyJWT: jest.fn(() => ({ id: "user-1", email: "admin@example.com" })),
+}));
+
+jest.mock("../../../../../lib/dns-provider", () => ({
+  __esModule: true,
+  checkDnsProvider: jest.fn(),
+}));
+
+import { verifyJWT } from "../../../../../lib/auth";
+import { checkDnsProvider } from "../../../../../lib/dns-provider";
+import { GET } from "../route";
+
+const verifyJWTMock = verifyJWT as jest.MockedFunction<typeof verifyJWT>;
+const checkDnsProviderMock = checkDnsProvider as jest.MockedFunction<
+  typeof checkDnsProvider
+>;
+
+const ORIGINAL_DNS_PROVIDER = process.env.DNS_PROVIDER;
+const ORIGINAL_HOSTED_ZONE_ID = process.env.AWS_HOSTED_ZONE_ID;
+const ORIGINAL_DO_API_TOKEN = process.env.DO_API_TOKEN;
+
+const SECRET_PATTERNS: ReadonlyArray<RegExp> = [
+  /AKIA[0-9A-Z]{16}/,
+  /Bearer\s+[A-Za-z0-9._-]+/,
+  /"secretAccessKey"/,
+  /"accessKeyId"/,
+];
+
+function buildAuthedRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/health/dns", {
+    headers: { authorization: "Bearer test-token" },
+  });
+}
+
+function buildUnauthedRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/health/dns");
+}
+
+function assertNoSecretsInBody(serialized: string): void {
+  for (const pattern of SECRET_PATTERNS) {
+    expect(serialized).not.toMatch(pattern);
+  }
+  expect(serialized).not.toContain("do-test-token-XXXXXXXXXXXXXXXX");
+  expect(serialized).not.toContain("AKIATESTKEY1234567890");
+}
+
+beforeEach(() => {
+  checkDnsProviderMock.mockReset();
+  verifyJWTMock.mockReset();
+  verifyJWTMock.mockReturnValue({ id: "user-1", email: "admin@example.com" });
+});
+
+afterEach(() => {
+  if (ORIGINAL_DNS_PROVIDER === undefined) delete process.env.DNS_PROVIDER;
+  else process.env.DNS_PROVIDER = ORIGINAL_DNS_PROVIDER;
+
+  if (ORIGINAL_HOSTED_ZONE_ID === undefined) delete process.env.AWS_HOSTED_ZONE_ID;
+  else process.env.AWS_HOSTED_ZONE_ID = ORIGINAL_HOSTED_ZONE_ID;
+
+  if (ORIGINAL_DO_API_TOKEN === undefined) delete process.env.DO_API_TOKEN;
+  else process.env.DO_API_TOKEN = ORIGINAL_DO_API_TOKEN;
+});
+
+describe("GET /api/health/dns — DigitalOcean active", () => {
+  beforeEach(() => {
+    process.env.DNS_PROVIDER = "digitalocean";
+  });
+
+  it("returns ok=true with detail.domainCount when token + listing succeed", async () => {
+    process.env.DO_API_TOKEN = "do-test-token-XXXXXXXXXXXXXXXX";
+    checkDnsProviderMock.mockResolvedValue({
+      ok: true,
+      provider: "digitalocean",
+      detail: { domainCount: 3 },
+    });
+
+    const response = await GET(buildAuthedRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      ok: true,
+      provider: "digitalocean",
+      detail: { domainCount: 3 },
+    });
+    assertNoSecretsInBody(JSON.stringify(body));
+  });
+
+  it("returns ok=false with name='MissingToken' when DO_API_TOKEN is unset", async () => {
+    delete process.env.DO_API_TOKEN;
+    checkDnsProviderMock.mockResolvedValue({
+      ok: false,
+      provider: "digitalocean",
+      error: {
+        name: "MissingToken",
+        message: "DO_API_TOKEN is not set",
+        httpStatusCode: null,
+      },
+    });
+
+    const response = await GET(buildAuthedRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      ok: false,
+      provider: "digitalocean",
+      error: {
+        name: "MissingToken",
+        message: "DO_API_TOKEN is not set",
+        httpStatusCode: null,
+      },
+    });
+    assertNoSecretsInBody(JSON.stringify(body));
+  });
+
+  it("returns ok=false with httpStatusCode=401 when DO API rejects the token", async () => {
+    process.env.DO_API_TOKEN = "do-test-token-XXXXXXXXXXXXXXXX";
+    checkDnsProviderMock.mockResolvedValue({
+      ok: false,
+      provider: "digitalocean",
+      error: {
+        name: "AxiosError",
+        message: "Request failed with status code 401",
+        httpStatusCode: 401,
+      },
+    });
+
+    const response = await GET(buildAuthedRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(false);
+    expect(body.error.httpStatusCode).toBe(401);
+    assertNoSecretsInBody(JSON.stringify(body));
+  });
+});
+
+describe("GET /api/health/dns — Route53 active", () => {
+  beforeEach(() => {
+    process.env.DNS_PROVIDER = "route53";
+  });
+
+  it("returns ok=true with hostedZoneCount=1 + pinnedZoneId when AWS_HOSTED_ZONE_ID is set + GetHostedZone succeeds", async () => {
+    process.env.AWS_HOSTED_ZONE_ID = "Z123EXAMPLE";
+    checkDnsProviderMock.mockResolvedValue({
+      ok: true,
+      provider: "route53",
+      detail: { hostedZoneCount: 1, pinnedZoneId: "Z123EXAMPLE" },
+    });
+
+    const response = await GET(buildAuthedRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      ok: true,
+      provider: "route53",
+      detail: { hostedZoneCount: 1, pinnedZoneId: "Z123EXAMPLE" },
+    });
+    assertNoSecretsInBody(JSON.stringify(body));
+  });
+
+  it("returns ok=true with hostedZoneCount=N + pinnedZoneId=null when zone id is unset (lists account zones)", async () => {
+    delete process.env.AWS_HOSTED_ZONE_ID;
+    checkDnsProviderMock.mockResolvedValue({
+      ok: true,
+      provider: "route53",
+      detail: { hostedZoneCount: 3, pinnedZoneId: null },
+    });
+
+    const response = await GET(buildAuthedRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.detail).toEqual({ hostedZoneCount: 3, pinnedZoneId: null });
+    assertNoSecretsInBody(JSON.stringify(body));
+  });
+
+  it("returns ok=false with httpStatusCode=403 on AccessDenied", async () => {
+    process.env.AWS_HOSTED_ZONE_ID = "Z123EXAMPLE";
+    checkDnsProviderMock.mockResolvedValue({
+      ok: false,
+      provider: "route53",
+      error: {
+        name: "AccessDeniedException",
+        message: "access denied for route53:GetHostedZone",
+        httpStatusCode: 403,
+      },
+    });
+
+    const response = await GET(buildAuthedRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(false);
+    expect(body.error.httpStatusCode).toBe(403);
+    expect(body.error.name).toBe("AccessDeniedException");
+    assertNoSecretsInBody(JSON.stringify(body));
+  });
+});
+
+describe("GET /api/health/dns — misconfiguration / auth", () => {
+  it("returns 500 when checkDnsProvider throws (e.g. unknown DNS_PROVIDER)", async () => {
+    process.env.DNS_PROVIDER = "cloudflare";
+    checkDnsProviderMock.mockRejectedValue(
+      new Error("Unsupported DNS_PROVIDER='cloudflare'.")
+    );
+
+    const response = await GET(buildAuthedRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    // Generic 500 — provider value is fine to surface (it's an env name,
+    // not a secret), but no SDK error fields leak.
+    assertNoSecretsInBody(JSON.stringify(body));
+  });
+
+  it("returns 401 when no Authorization header is present (withAuth gate)", async () => {
+    process.env.DNS_PROVIDER = "digitalocean";
+
+    const response = await GET(buildUnauthedRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toMatch(/authorization/i);
+    expect(checkDnsProviderMock).not.toHaveBeenCalled();
+    assertNoSecretsInBody(JSON.stringify(body));
+  });
+});

--- a/src/app/api/health/dns/route.ts
+++ b/src/app/api/health/dns/route.ts
@@ -1,0 +1,57 @@
+/**
+ * GET /api/health/dns — admin-only DNS provider health probe.
+ *
+ * Dispatches to the active DNS provider (`DNS_PROVIDER` env) via
+ * `checkDnsProvider()` and returns its `DnsHealth` shape verbatim.
+ *
+ * Response policy (see plan 009):
+ *   - HTTP 200 for both `ok: true` and `ok: false` so the UI handles a
+ *     single fetch result path. The `ok` discriminator drives the
+ *     dashboard's success/error rendering.
+ *   - HTTP 401 when the JWT is missing or invalid (auth gate).
+ *   - HTTP 500 only when `checkDnsProvider()` itself throws — which
+ *     today happens only on an unknown `DNS_PROVIDER` value (fail-fast
+ *     misconfiguration signal during operator setup). The body is the
+ *     generic error shape.
+ *   - The provider's `checkProvider()` already enforces the
+ *     `{ name, message, httpStatusCode }` whitelist on errors, so no
+ *     SDK / axios error transitively reaches the response payload.
+ *
+ * Auth: inline `verifyJWT` mirrors the pattern in
+ * `src/app/api/{auth/me,domains}/route.ts`. See plan 009 "후속 트랙
+ * 후보" for the `withAuth` wrapper refactor that would let this be
+ * `export const GET = withAuth(...)`.
+ */
+import { NextRequest, NextResponse } from "next/server";
+
+import { verifyJWT } from "@/lib/auth";
+import { checkDnsProvider } from "@/lib/dns-provider";
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return NextResponse.json(
+      { error: "Missing or invalid authorization header" },
+      { status: 401 }
+    );
+  }
+  const token = authHeader.substring(7);
+  const user = verifyJWT(token);
+  if (!user) {
+    return NextResponse.json(
+      { error: "Invalid or expired token" },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const result = await checkDnsProvider();
+    return NextResponse.json(result);
+  } catch (error: unknown) {
+    console.error("DNS health probe error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/health/ses/__tests__/route.test.ts
+++ b/src/app/api/health/ses/__tests__/route.test.ts
@@ -1,0 +1,214 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for src/app/api/health/ses/route.ts (admin SES health probe).
+ *
+ * Strategy:
+ *   - aws-sdk-client-mock intercepts SESv2Client.send() so no live AWS call
+ *     is ever made.
+ *   - JWT verification is mocked at the module boundary so the route's
+ *     `withAuth` wrapping can be exercised without a live secret + token.
+ *   - Every assertion includes a secret-pattern sanity check on the
+ *     serialized response body to enforce the project secret policy
+ *     (no AKIA*, Bearer, accessKeyId, secretAccessKey, DO_API_TOKEN).
+ *
+ * Environment is `node` (not jsdom) because NextRequest depends on the
+ * fetch / Request globals provided by Node 18+ but absent from jsdom.
+ */
+import { mockClient } from "aws-sdk-client-mock";
+import { NextRequest } from "next/server";
+import { GetAccountCommand, SESv2Client } from "@aws-sdk/client-sesv2";
+
+// Mock just the auth helper so the real route's inline `verifyJWT`
+// gate can be exercised end-to-end without depending on a live JWT
+// secret. The auth module is small (no transitive ESM chain) so a
+// shallow mock is enough.
+jest.mock("../../../../../lib/auth", () => ({
+  __esModule: true,
+  verifyJWT: jest.fn(() => ({ id: "user-1", email: "admin@example.com" })),
+}));
+
+import { verifyJWT } from "../../../../../lib/auth";
+import { GET } from "../route";
+
+const verifyJWTMock = verifyJWT as jest.MockedFunction<typeof verifyJWT>;
+const sesMock = mockClient(SESv2Client);
+
+const ORIGINAL_REGION = process.env.AWS_REGION;
+const ORIGINAL_ACCESS_KEY = process.env.AWS_ACCESS_KEY_ID;
+const ORIGINAL_SECRET_KEY = process.env.AWS_SECRET_ACCESS_KEY;
+
+// Forbidden patterns in the serialized response body (secret policy).
+const SECRET_PATTERNS: ReadonlyArray<RegExp> = [
+  /AKIA[0-9A-Z]{16}/,
+  /Bearer\s+[A-Za-z0-9._-]+/,
+  /"secretAccessKey"/,
+  /"accessKeyId"/,
+];
+
+function buildAuthedRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/health/ses", {
+    headers: { authorization: "Bearer test-token" },
+  });
+}
+
+function buildUnauthedRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/health/ses");
+}
+
+function assertNoSecretsInBody(serialized: string): void {
+  for (const pattern of SECRET_PATTERNS) {
+    expect(serialized).not.toMatch(pattern);
+  }
+  // Also sanity-check that the literal env values used in test setup do
+  // not leak into the response.
+  expect(serialized).not.toContain("AKIATESTKEY1234567890");
+  expect(serialized).not.toContain("super-secret-aws-secret");
+}
+
+beforeEach(() => {
+  sesMock.reset();
+  verifyJWTMock.mockReset();
+  verifyJWTMock.mockReturnValue({ id: "user-1", email: "admin@example.com" });
+
+  process.env.AWS_REGION = "us-east-1";
+  process.env.AWS_ACCESS_KEY_ID = "AKIATESTKEY1234567890";
+  process.env.AWS_SECRET_ACCESS_KEY = "super-secret-aws-secret";
+});
+
+afterEach(() => {
+  if (ORIGINAL_REGION === undefined) delete process.env.AWS_REGION;
+  else process.env.AWS_REGION = ORIGINAL_REGION;
+
+  if (ORIGINAL_ACCESS_KEY === undefined) delete process.env.AWS_ACCESS_KEY_ID;
+  else process.env.AWS_ACCESS_KEY_ID = ORIGINAL_ACCESS_KEY;
+
+  if (ORIGINAL_SECRET_KEY === undefined) delete process.env.AWS_SECRET_ACCESS_KEY;
+  else process.env.AWS_SECRET_ACCESS_KEY = ORIGINAL_SECRET_KEY;
+});
+
+describe("GET /api/health/ses", () => {
+  it("returns ok=true with full quota + non-sandbox flags on a healthy production account", async () => {
+    sesMock.on(GetAccountCommand).resolves({
+      ProductionAccessEnabled: true,
+      SendingEnabled: true,
+      EnforcementStatus: "HEALTHY",
+      SendQuota: {
+        Max24HourSend: 50000,
+        MaxSendRate: 14,
+        SentLast24Hours: 200,
+      },
+    });
+
+    const response = await GET(buildAuthedRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      ok: true,
+      region: "us-east-1",
+      sandbox: false,
+      sendingEnabled: true,
+      enforcementStatus: "HEALTHY",
+      sendQuota: {
+        max24HourSend: 50000,
+        maxSendRate: 14,
+        sentLast24Hours: 200,
+      },
+    });
+
+    assertNoSecretsInBody(JSON.stringify(body));
+    expect(sesMock.commandCalls(GetAccountCommand)).toHaveLength(1);
+  });
+
+  it("reports sandbox=true when ProductionAccessEnabled is false", async () => {
+    sesMock.on(GetAccountCommand).resolves({
+      ProductionAccessEnabled: false,
+      SendingEnabled: true,
+      EnforcementStatus: "HEALTHY",
+      SendQuota: {
+        Max24HourSend: 200,
+        MaxSendRate: 1,
+        SentLast24Hours: 0,
+      },
+    });
+
+    const response = await GET(buildAuthedRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.sandbox).toBe(true);
+    assertNoSecretsInBody(JSON.stringify(body));
+  });
+
+  it("reports ok=false with httpStatusCode=403 on IAM access denied (whitelist serializes only name/message/httpStatusCode)", async () => {
+    const err = Object.assign(new Error("not authorized to perform ses:GetAccount"), {
+      name: "AccessDeniedException",
+      $metadata: { httpStatusCode: 403 },
+    });
+    sesMock.on(GetAccountCommand).rejects(err);
+
+    const response = await GET(buildAuthedRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      ok: false,
+      region: "us-east-1",
+      error: {
+        name: "AccessDeniedException",
+        message: "not authorized to perform ses:GetAccount",
+        httpStatusCode: 403,
+      },
+    });
+    assertNoSecretsInBody(JSON.stringify(body));
+  });
+
+  it("reports ok=false with httpStatusCode=null on a network error (no $metadata)", async () => {
+    const err = Object.assign(new Error("ECONNREFUSED"), { name: "Error" });
+    sesMock.on(GetAccountCommand).rejects(err);
+
+    const response = await GET(buildAuthedRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(false);
+    expect(body.region).toBe("us-east-1");
+    expect(body.error).toEqual({
+      name: "Error",
+      message: "ECONNREFUSED",
+      httpStatusCode: null,
+    });
+    assertNoSecretsInBody(JSON.stringify(body));
+  });
+
+  it("returns ok=true with sendQuota=null when SendQuota is absent in the response", async () => {
+    sesMock.on(GetAccountCommand).resolves({
+      ProductionAccessEnabled: false,
+      SendingEnabled: true,
+      EnforcementStatus: "HEALTHY",
+      // SendQuota intentionally omitted (some sandbox accounts).
+    });
+
+    const response = await GET(buildAuthedRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.sendQuota).toBeNull();
+    expect(body.sandbox).toBe(true);
+    assertNoSecretsInBody(JSON.stringify(body));
+  });
+
+  it("returns 401 when no Authorization header is present (withAuth gate)", async () => {
+    const response = await GET(buildUnauthedRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toMatch(/authorization/i);
+    // No SES call should have been issued.
+    expect(sesMock.commandCalls(GetAccountCommand)).toHaveLength(0);
+    assertNoSecretsInBody(JSON.stringify(body));
+  });
+});

--- a/src/app/api/health/ses/route.ts
+++ b/src/app/api/health/ses/route.ts
@@ -1,0 +1,143 @@
+/**
+ * GET /api/health/ses — admin-only SES health probe.
+ *
+ * Issues a single SESv2 `GetAccountCommand` and normalizes the response
+ * into a fixed schema that the dashboard's Connections tab consumes.
+ *
+ * Response policy (see plan 009):
+ *   - HTTP 200 for both `ok: true` and `ok: false` so the UI handles a
+ *     single fetch result path. A non-200 status means auth failed
+ *     (401) or the route handler itself blew up (500, defensive
+ *     try/catch around the normalizer).
+ *   - Errors are reduced to a `{ name, message, httpStatusCode }`
+ *     whitelist — the raw error object is never serialized because AWS
+ *     SDK errors can transitively reference request headers (including
+ *     the `Authorization` header bearing the AWS SigV4 signature).
+ *   - No AWS access key id / secret key / DO API token / JWT is ever
+ *     part of the response payload. Only `region` and account-shape
+ *     diagnostics (`sandbox`, `sendingEnabled`, `enforcementStatus`,
+ *     `sendQuota`) are returned.
+ *
+ * Auth: inline `verifyJWT` mirrors the pattern in
+ * `src/app/api/{auth/me,domains}/route.ts`. The reusable `withAuth`
+ * wrapper in `src/lib/middleware.ts` is incompatible with Next.js 15's
+ * route export validator (its generic second argument is rejected as
+ * `RouteContext<...> | undefined`); refactoring it is captured as a
+ * follow-up in plan 009 "후속 트랙 후보".
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { GetAccountCommand, SESv2Client } from "@aws-sdk/client-sesv2";
+
+import { verifyJWT } from "@/lib/auth";
+
+interface SesSendQuota {
+  max24HourSend: number;
+  maxSendRate: number;
+  sentLast24Hours: number;
+}
+
+type SesHealthResponse =
+  | {
+      ok: true;
+      region: string;
+      sandbox: boolean;
+      sendingEnabled: boolean;
+      enforcementStatus: string | null;
+      sendQuota: SesSendQuota | null;
+    }
+  | {
+      ok: false;
+      region: string;
+      error: { name: string; message: string; httpStatusCode: number | null };
+    };
+
+/**
+ * Build a fresh SESv2 client per call. Mirrors the lazy pattern in
+ * `src/lib/ses.ts` so credential rotation is safe and the test runtime
+ * can mutate AWS env between cases without re-importing the module.
+ */
+function getSesClient(): SESv2Client {
+  return new SESv2Client({
+    region: process.env.AWS_REGION || "us-east-1",
+    credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+    },
+  });
+}
+
+/**
+ * Whitelist-only error normalization — never reflect arbitrary error
+ * fields back to the client. The AWS SDK puts the request context (with
+ * its SigV4 `Authorization` header) on `error.$metadata` siblings on
+ * some failure modes; spreading the raw error would leak it.
+ */
+function normalizeError(error: unknown): {
+  name: string;
+  message: string;
+  httpStatusCode: number | null;
+} {
+  const errObj = error as {
+    name?: string;
+    message?: string;
+    $metadata?: { httpStatusCode?: number };
+  };
+  return {
+    name: errObj.name || "Error",
+    message: errObj.message || "Unknown error",
+    httpStatusCode: errObj.$metadata?.httpStatusCode ?? null,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return NextResponse.json(
+      { error: "Missing or invalid authorization header" },
+      { status: 401 }
+    );
+  }
+  const token = authHeader.substring(7);
+  const user = verifyJWT(token);
+  if (!user) {
+    return NextResponse.json(
+      { error: "Invalid or expired token" },
+      { status: 401 }
+    );
+  }
+
+  const region = process.env.AWS_REGION || "us-east-1";
+
+  let body: SesHealthResponse;
+  try {
+    const response = await getSesClient().send(new GetAccountCommand({}));
+
+    const sendQuota: SesSendQuota | null = response.SendQuota
+      ? {
+          max24HourSend: response.SendQuota.Max24HourSend ?? 0,
+          maxSendRate: response.SendQuota.MaxSendRate ?? 0,
+          sentLast24Hours: response.SendQuota.SentLast24Hours ?? 0,
+        }
+      : null;
+
+    body = {
+      ok: true,
+      region,
+      // ProductionAccessEnabled === true means the account has been
+      // promoted out of sandbox; falsey (false / undefined) means
+      // sandbox.
+      sandbox: !response.ProductionAccessEnabled,
+      sendingEnabled: response.SendingEnabled ?? false,
+      enforcementStatus: response.EnforcementStatus ?? null,
+      sendQuota,
+    };
+  } catch (error: unknown) {
+    body = {
+      ok: false,
+      region,
+      error: normalizeError(error),
+    };
+  }
+
+  return NextResponse.json(body);
+}

--- a/src/components/ConnectionsTab.tsx
+++ b/src/components/ConnectionsTab.tsx
@@ -1,0 +1,340 @@
+"use client";
+
+/**
+ * Admin Connections tab — surfaces the read-only health of SES + the
+ * active DNS provider in two side-by-side cards.
+ *
+ * Render policy (see plan 009):
+ *   - Mount once: both `/api/health/ses` and `/api/health/dns` are
+ *     fetched in parallel via `Promise.all`. The button issues the same
+ *     pair of fetches on demand. No automatic polling — operator
+ *     intent only (auto-polling is in the "후속 트랙 후보" follow-up).
+ *   - Each card runs through three independent badges: `loading`
+ *     (gray) -> `ok` (green) / `error` (red). One side's failure never
+ *     hides the other side's data.
+ *   - Only operator diagnostics are rendered: region, sandbox flag,
+ *     send quota numbers, provider name, hosted-zone counts, error
+ *     `name` + `message`. Never AWS access keys, DO tokens, JWTs.
+ */
+
+import React, { useCallback, useEffect, useState } from "react";
+
+interface SesSendQuota {
+  max24HourSend: number;
+  maxSendRate: number;
+  sentLast24Hours: number;
+}
+
+type SesHealth =
+  | {
+      ok: true;
+      region: string;
+      sandbox: boolean;
+      sendingEnabled: boolean;
+      enforcementStatus: string | null;
+      sendQuota: SesSendQuota | null;
+    }
+  | {
+      ok: false;
+      region: string;
+      error: { name: string; message: string; httpStatusCode: number | null };
+    };
+
+type DnsHealth =
+  | {
+      ok: true;
+      provider: "digitalocean";
+      detail: { domainCount: number };
+    }
+  | {
+      ok: true;
+      provider: "route53";
+      detail: { hostedZoneCount: number; pinnedZoneId: string | null };
+    }
+  | {
+      ok: false;
+      provider: "digitalocean" | "route53";
+      error: { name: string; message: string; httpStatusCode: number | null };
+    };
+
+type CardState<T> =
+  | { state: "loading" }
+  | { state: "ok"; data: T }
+  | { state: "error"; message: string };
+
+function StatusBadge({ state }: { state: CardState<unknown>["state"] }) {
+  const styles: Record<CardState<unknown>["state"], string> = {
+    loading: "bg-gray-100 text-gray-700",
+    ok: "bg-green-100 text-green-800",
+    error: "bg-red-100 text-red-800",
+  };
+  const labels: Record<CardState<unknown>["state"], string> = {
+    loading: "loading",
+    ok: "ok",
+    error: "error",
+  };
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${styles[state]}`}
+    >
+      {labels[state]}
+    </span>
+  );
+}
+
+function authHeaders(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+  const token = window.localStorage.getItem("auth_token");
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function fetchHealth<T>(path: string): Promise<T> {
+  const response = await fetch(path, { headers: authHeaders() });
+  // The /api/health/* routes return HTTP 200 even for `ok: false`
+  // (single result path policy). Non-200 means the route handler
+  // itself failed — surface as a thrown error so the card flips to
+  // the `error` state with a generic message.
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  return (await response.json()) as T;
+}
+
+export default function ConnectionsTab() {
+  const [ses, setSes] = useState<CardState<SesHealth>>({ state: "loading" });
+  const [dns, setDns] = useState<CardState<DnsHealth>>({ state: "loading" });
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const loadHealth = useCallback(async () => {
+    setSes({ state: "loading" });
+    setDns({ state: "loading" });
+    setIsRefreshing(true);
+
+    const sesPromise = fetchHealth<SesHealth>("/api/health/ses").then(
+      (data): CardState<SesHealth> => ({ state: "ok", data }),
+      (err: Error): CardState<SesHealth> => ({
+        state: "error",
+        message: err.message || "fetch failed",
+      })
+    );
+    const dnsPromise = fetchHealth<DnsHealth>("/api/health/dns").then(
+      (data): CardState<DnsHealth> => ({ state: "ok", data }),
+      (err: Error): CardState<DnsHealth> => ({
+        state: "error",
+        message: err.message || "fetch failed",
+      })
+    );
+
+    const [sesResult, dnsResult] = await Promise.all([sesPromise, dnsPromise]);
+    setSes(sesResult);
+    setDns(dnsResult);
+    setIsRefreshing(false);
+  }, []);
+
+  useEffect(() => {
+    void loadHealth();
+  }, [loadHealth]);
+
+  return (
+    <div className="space-y-6">
+      <div className="sm:flex sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-gray-900">Connections</h1>
+          <p className="mt-2 text-sm text-gray-700">
+            Read-only health of Amazon SES and the active DNS provider. No
+            domains are created and no messages are sent.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void loadHealth()}
+          disabled={isRefreshing}
+          className="mt-3 sm:mt-0 inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isRefreshing ? "Refreshing..." : "Refresh"}
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <SesCard state={ses} />
+        <DnsCard state={dns} />
+      </div>
+    </div>
+  );
+}
+
+function SesCard({ state }: { state: CardState<SesHealth> }) {
+  const badge =
+    state.state === "loading"
+      ? "loading"
+      : state.state === "error" || (state.state === "ok" && !state.data.ok)
+        ? "error"
+        : "ok";
+
+  return (
+    <section
+      data-testid="connections-card-ses"
+      className="bg-white shadow rounded-lg p-6"
+    >
+      <header className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-medium text-gray-900">Amazon SES</h2>
+        <StatusBadge state={badge} />
+      </header>
+
+      {state.state === "loading" && (
+        <p className="text-sm text-gray-500">Probing SES account…</p>
+      )}
+
+      {state.state === "error" && (
+        <ErrorBlock title="Health check failed" message={state.message} />
+      )}
+
+      {state.state === "ok" && !state.data.ok && (
+        <ErrorBlock
+          title={state.data.error.name}
+          message={state.data.error.message}
+          httpStatusCode={state.data.error.httpStatusCode}
+          region={state.data.region}
+        />
+      )}
+
+      {state.state === "ok" && state.data.ok && (
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+          <Row label="Region" value={state.data.region} />
+          <Row label="Sandbox" value={state.data.sandbox ? "yes" : "no"} />
+          <Row
+            label="Sending enabled"
+            value={state.data.sendingEnabled ? "yes" : "no"}
+          />
+          <Row
+            label="Enforcement"
+            value={state.data.enforcementStatus ?? "—"}
+          />
+          {state.data.sendQuota ? (
+            <>
+              <Row
+                label="Max 24h send"
+                value={String(state.data.sendQuota.max24HourSend)}
+              />
+              <Row
+                label="Max send rate"
+                value={String(state.data.sendQuota.maxSendRate)}
+              />
+              <Row
+                label="Sent last 24h"
+                value={String(state.data.sendQuota.sentLast24Hours)}
+              />
+            </>
+          ) : (
+            <Row label="Send quota" value="not reported" />
+          )}
+        </dl>
+      )}
+    </section>
+  );
+}
+
+function DnsCard({ state }: { state: CardState<DnsHealth> }) {
+  const badge =
+    state.state === "loading"
+      ? "loading"
+      : state.state === "error" || (state.state === "ok" && !state.data.ok)
+        ? "error"
+        : "ok";
+
+  return (
+    <section
+      data-testid="connections-card-dns"
+      className="bg-white shadow rounded-lg p-6"
+    >
+      <header className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-medium text-gray-900">DNS Provider</h2>
+        <StatusBadge state={badge} />
+      </header>
+
+      {state.state === "loading" && (
+        <p className="text-sm text-gray-500">Probing DNS provider…</p>
+      )}
+
+      {state.state === "error" && (
+        <ErrorBlock title="Health check failed" message={state.message} />
+      )}
+
+      {state.state === "ok" && !state.data.ok && (
+        <ErrorBlock
+          title={state.data.error.name}
+          message={state.data.error.message}
+          httpStatusCode={state.data.error.httpStatusCode}
+          provider={state.data.provider}
+        />
+      )}
+
+      {state.state === "ok" && state.data.ok && (
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+          <Row label="Provider" value={state.data.provider} />
+          {state.data.provider === "digitalocean" ? (
+            <Row
+              label="Domains"
+              value={String(state.data.detail.domainCount)}
+            />
+          ) : (
+            <>
+              <Row
+                label="Hosted zones"
+                value={String(state.data.detail.hostedZoneCount)}
+              />
+              <Row
+                label="Pinned zone"
+                value={state.data.detail.pinnedZoneId ?? "auto-discover"}
+              />
+            </>
+          )}
+        </dl>
+      )}
+    </section>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <>
+      <dt className="text-gray-500">{label}</dt>
+      <dd className="font-medium text-gray-900">{value}</dd>
+    </>
+  );
+}
+
+function ErrorBlock(props: {
+  title: string;
+  message: string;
+  httpStatusCode?: number | null;
+  region?: string;
+  provider?: string;
+}) {
+  return (
+    <div className="bg-red-50 border border-red-200 rounded-md p-3 text-sm text-red-900">
+      <div className="font-medium">{props.title}</div>
+      <div className="mt-1 break-words">{props.message}</div>
+      <div className="mt-2 grid grid-cols-2 gap-x-4 text-xs text-red-800">
+        {props.region !== undefined && (
+          <>
+            <div className="text-red-600">Region</div>
+            <div>{props.region}</div>
+          </>
+        )}
+        {props.provider !== undefined && (
+          <>
+            <div className="text-red-600">Provider</div>
+            <div>{props.provider}</div>
+          </>
+        )}
+        {props.httpStatusCode !== undefined && (
+          <>
+            <div className="text-red-600">HTTP status</div>
+            <div>{props.httpStatusCode ?? "—"}</div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -5,8 +5,9 @@ import { useAuth } from "@/contexts/AuthContext";
 import DomainsTab from "./DomainsTab";
 import ApiKeysTab from "./ApiKeysTab";
 import EmailLogsTab from "./EmailLogsTab";
+import ConnectionsTab from "./ConnectionsTab";
 
-type Tab = "domains" | "apikeys" | "logs";
+type Tab = "domains" | "apikeys" | "logs" | "connections";
 
 export default function Dashboard() {
   const { user, logout } = useAuth();
@@ -27,6 +28,11 @@ export default function Dashboard() {
       id: "logs" as Tab,
       name: "Email Logs",
       description: "View sent email history",
+    },
+    {
+      id: "connections" as Tab,
+      name: "Connections",
+      description: "SES & DNS provider health",
     },
   ];
 
@@ -82,6 +88,7 @@ export default function Dashboard() {
           {activeTab === "domains" && <DomainsTab />}
           {activeTab === "apikeys" && <ApiKeysTab />}
           {activeTab === "logs" && <EmailLogsTab />}
+          {activeTab === "connections" && <ConnectionsTab />}
         </div>
       </main>
 

--- a/src/components/__tests__/ConnectionsTab.test.tsx
+++ b/src/components/__tests__/ConnectionsTab.test.tsx
@@ -1,0 +1,262 @@
+/**
+ * Component tests for ConnectionsTab — admin Connections health view.
+ *
+ * Strategy:
+ *   - `global.fetch` is mocked per case so we drive the component into
+ *     each render branch (loading -> ok / error / one-side error /
+ *     refresh) without coupling to the real /api/health/* routes.
+ *   - localStorage is mocked to provide an auth_token so the component's
+ *     Authorization header is consistent across cases.
+ *   - Every assertion includes a secret-pattern sanity check on the
+ *     full rendered HTML to enforce the project secret policy
+ *     (no AKIA*, no Bearer values, no secretAccessKey labels).
+ */
+import React from "react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import ConnectionsTab from "../ConnectionsTab";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+const localStorageMock = {
+  getItem: jest.fn((key: string) =>
+    key === "auth_token" ? "test-jwt-token" : null
+  ),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  clear: jest.fn(),
+};
+// @ts-expect-error - mock localStorage
+global.localStorage = localStorageMock;
+
+const SECRET_PATTERNS: ReadonlyArray<RegExp> = [
+  /AKIA[0-9A-Z]{16}/,
+  /Bearer\s+[A-Za-z0-9._-]+/,
+  /secretAccessKey/i,
+];
+
+function assertNoSecretsInDom(container: HTMLElement): void {
+  const html = container.innerHTML;
+  for (const pattern of SECRET_PATTERNS) {
+    expect(html).not.toMatch(pattern);
+  }
+}
+
+function buildJsonResponse(body: unknown, init: { status?: number } = {}) {
+  return {
+    ok: (init.status ?? 200) < 400,
+    status: init.status ?? 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  localStorageMock.getItem.mockClear();
+});
+
+describe("ConnectionsTab", () => {
+  it("calls both /api/health/ses and /api/health/dns on mount", async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/api/health/ses")) {
+        return buildJsonResponse({
+          ok: true,
+          region: "us-east-1",
+          sandbox: false,
+          sendingEnabled: true,
+          enforcementStatus: "HEALTHY",
+          sendQuota: {
+            max24HourSend: 50000,
+            maxSendRate: 14,
+            sentLast24Hours: 200,
+          },
+        });
+      }
+      return buildJsonResponse({
+        ok: true,
+        provider: "digitalocean",
+        detail: { domainCount: 3 },
+      });
+    });
+
+    render(<ConnectionsTab />);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    const calledUrls = mockFetch.mock.calls.map((args) => args[0] as string);
+    expect(calledUrls.some((u) => u.includes("/api/health/ses"))).toBe(true);
+    expect(calledUrls.some((u) => u.includes("/api/health/dns"))).toBe(true);
+  });
+
+  it("renders loading state initially, then ok cards with provider data", async () => {
+    let resolveSes: (value: Response) => void = () => {};
+    let resolveDns: (value: Response) => void = () => {};
+    const sesPromise = new Promise<Response>((r) => {
+      resolveSes = r;
+    });
+    const dnsPromise = new Promise<Response>((r) => {
+      resolveDns = r;
+    });
+
+    mockFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/api/health/ses")) {
+        return sesPromise;
+      }
+      return dnsPromise;
+    });
+
+    const { container } = render(<ConnectionsTab />);
+
+    // Loading badges are visible before the fetches resolve.
+    const loadingBadges = await screen.findAllByText(/loading/i);
+    expect(loadingBadges.length).toBeGreaterThanOrEqual(2);
+
+    resolveSes(
+      buildJsonResponse({
+        ok: true,
+        region: "us-east-1",
+        sandbox: false,
+        sendingEnabled: true,
+        enforcementStatus: "HEALTHY",
+        sendQuota: {
+          max24HourSend: 50000,
+          maxSendRate: 14,
+          sentLast24Hours: 200,
+        },
+      })
+    );
+    resolveDns(
+      buildJsonResponse({
+        ok: true,
+        provider: "route53",
+        detail: { hostedZoneCount: 2, pinnedZoneId: "Z123EXAMPLE" },
+      })
+    );
+
+    await waitFor(() => {
+      expect(screen.queryAllByText(/loading/i).length).toBe(0);
+    });
+
+    // SES card surfaces region + sendQuota / sandbox flags.
+    expect(screen.getByText("us-east-1")).toBeInTheDocument();
+    expect(screen.getByText("50000")).toBeInTheDocument();
+    expect(screen.getByText("HEALTHY")).toBeInTheDocument();
+
+    // DNS card surfaces provider + hostedZoneCount + pinnedZoneId.
+    expect(screen.getByText("route53")).toBeInTheDocument();
+    expect(screen.getByText("Z123EXAMPLE")).toBeInTheDocument();
+
+    assertNoSecretsInDom(container);
+  });
+
+  it("renders an error badge on one card while the other reports ok (independent failure isolation)", async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/api/health/ses")) {
+        // SES network error path.
+        throw new Error("network unreachable");
+      }
+      return buildJsonResponse({
+        ok: true,
+        provider: "digitalocean",
+        detail: { domainCount: 4 },
+      });
+    });
+
+    const { container } = render(<ConnectionsTab />);
+
+    await waitFor(() => {
+      // SES card -> error badge, DNS card -> ok badge.
+      const sesCard = screen.getByTestId("connections-card-ses");
+      const dnsCard = screen.getByTestId("connections-card-dns");
+      expect(within(sesCard).getByText(/error/i)).toBeInTheDocument();
+      expect(within(dnsCard).getByText(/ok/i)).toBeInTheDocument();
+    });
+
+    // DNS card should still show its provider data.
+    expect(screen.getByText("digitalocean")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+
+    assertNoSecretsInDom(container);
+  });
+
+  it("re-issues both fetches when the Refresh button is clicked", async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/api/health/ses")) {
+        return buildJsonResponse({
+          ok: true,
+          region: "us-east-1",
+          sandbox: true,
+          sendingEnabled: true,
+          enforcementStatus: "HEALTHY",
+          sendQuota: null,
+        });
+      }
+      return buildJsonResponse({
+        ok: true,
+        provider: "digitalocean",
+        detail: { domainCount: 1 },
+      });
+    });
+
+    render(<ConnectionsTab />);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    const refreshButton = screen.getByRole("button", { name: /refresh/i });
+    const user = userEvent.setup();
+    await user.click(refreshButton);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  it("never renders secret patterns even when the response carries an error message", async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (typeof url === "string" && url.includes("/api/health/ses")) {
+        return buildJsonResponse({
+          ok: false,
+          region: "us-east-1",
+          error: {
+            name: "AccessDeniedException",
+            message: "not authorized to perform ses:GetAccount",
+            httpStatusCode: 403,
+          },
+        });
+      }
+      return buildJsonResponse({
+        ok: false,
+        provider: "route53",
+        error: {
+          name: "AccessDeniedException",
+          message: "access denied for route53:ListHostedZones",
+          httpStatusCode: 403,
+        },
+      });
+    });
+
+    const { container } = render(<ConnectionsTab />);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    // Error names + messages should be surfaced — they're operator
+    // diagnostics, not secrets. The fetch resolves async, so wait for
+    // the rendered DOM to flush past the loading state.
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(/AccessDeniedException/).length
+      ).toBeGreaterThan(0);
+    });
+    assertNoSecretsInDom(container);
+  });
+});

--- a/src/lib/__tests__/digitalocean.test.ts
+++ b/src/lib/__tests__/digitalocean.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for src/lib/digitalocean.ts (DigitalOcean DNS API wrapper).
+ *
+ * Strategy: jest.mock("axios", ...) intercepts the http calls so no
+ * live DigitalOcean request is ever made. The wider DigitalOcean
+ * surface (setup / records CRUD) is exercised indirectly by
+ * `domains-dns-integration.test.ts`; this file focuses on `checkProvider`
+ * as a standalone health probe.
+ *
+ * Env isolation: `DO_API_TOKEN` is set/torn down per case so the lazy
+ * `getApiToken()` capture in digitalocean.ts sees the right value, and
+ * no leak occurs across the suite.
+ */
+jest.mock("axios", () => ({
+  __esModule: true,
+  default: { create: jest.fn() },
+}));
+
+import axios from "axios";
+import { checkProvider } from "../digitalocean";
+
+const axiosCreateMock = (axios as unknown as { create: jest.Mock }).create;
+
+const ORIGINAL_DO_API_TOKEN = process.env.DO_API_TOKEN;
+
+function mockDoClient(impl: { get: jest.Mock }): void {
+  axiosCreateMock.mockReturnValue(impl);
+}
+
+beforeEach(() => {
+  axiosCreateMock.mockReset();
+});
+
+afterEach(() => {
+  if (ORIGINAL_DO_API_TOKEN === undefined) {
+    delete process.env.DO_API_TOKEN;
+  } else {
+    process.env.DO_API_TOKEN = ORIGINAL_DO_API_TOKEN;
+  }
+});
+
+describe("checkProvider (DigitalOcean)", () => {
+  it("returns ok=false with name='MissingToken' when DO_API_TOKEN is unset (no axios call)", async () => {
+    delete process.env.DO_API_TOKEN;
+
+    const result = await checkProvider();
+
+    expect(result).toEqual({
+      ok: false,
+      provider: "digitalocean",
+      error: {
+        name: "MissingToken",
+        message: "DO_API_TOKEN is not set",
+        httpStatusCode: null,
+      },
+    });
+    // No axios.create / no http call expected.
+    expect(axiosCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns ok=true with detail.domainCount when the token is valid and the API responds 200", async () => {
+    process.env.DO_API_TOKEN = "do-test-token-XXXXXXXXXXXXXXXX";
+    const get = jest.fn().mockResolvedValue({
+      data: {
+        domains: [
+          { name: "example.com", zone_file: "" },
+          { name: "example.org", zone_file: "" },
+          { name: "example.net", zone_file: "" },
+        ],
+      },
+    });
+    mockDoClient({ get });
+
+    const result = await checkProvider();
+
+    expect(result).toEqual({
+      ok: true,
+      provider: "digitalocean",
+      detail: { domainCount: 3 },
+    });
+    expect(get).toHaveBeenCalledWith("/domains");
+  });
+
+  it("returns ok=false with httpStatusCode=401 when the API rejects the token", async () => {
+    process.env.DO_API_TOKEN = "do-test-token-XXXXXXXXXXXXXXXX";
+    const axiosErr = Object.assign(new Error("Request failed with status code 401"), {
+      name: "AxiosError",
+      response: { status: 401 },
+    });
+    const get = jest.fn().mockRejectedValue(axiosErr);
+    mockDoClient({ get });
+
+    const result = await checkProvider();
+
+    expect(result).toEqual({
+      ok: false,
+      provider: "digitalocean",
+      error: {
+        name: "AxiosError",
+        message: "Request failed with status code 401",
+        httpStatusCode: 401,
+      },
+    });
+
+    // Sanity: serialized form must NOT contain the literal token (no
+    // header/body echo).
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("do-test-token-XXXXXXXXXXXXXXXX");
+    expect(serialized).not.toMatch(/Bearer\s+/);
+  });
+});

--- a/src/lib/__tests__/dns-provider.test.ts
+++ b/src/lib/__tests__/dns-provider.test.ts
@@ -12,14 +12,17 @@ jest.mock("../digitalocean", () => ({
   __esModule: true,
   setupDomainDNS: jest.fn(),
   verifyDomainOwnership: jest.fn(),
+  checkProvider: jest.fn(),
 }));
 jest.mock("../route53", () => ({
   __esModule: true,
   setupDomainDNS: jest.fn(),
   verifyDomainOwnership: jest.fn(),
+  checkProvider: jest.fn(),
 }));
 
 import {
+  checkDnsProvider,
   getDnsProviderName,
   setupDomainDNS,
   verifyDomainOwnership,
@@ -33,11 +36,17 @@ const doSetupMock = digitalocean.setupDomainDNS as jest.MockedFunction<
 const doVerifyMock = digitalocean.verifyDomainOwnership as jest.MockedFunction<
   typeof digitalocean.verifyDomainOwnership
 >;
+const doCheckMock = digitalocean.checkProvider as jest.MockedFunction<
+  typeof digitalocean.checkProvider
+>;
 const r53SetupMock = route53.setupDomainDNS as jest.MockedFunction<
   typeof route53.setupDomainDNS
 >;
 const r53VerifyMock = route53.verifyDomainOwnership as jest.MockedFunction<
   typeof route53.verifyDomainOwnership
+>;
+const r53CheckMock = route53.checkProvider as jest.MockedFunction<
+  typeof route53.checkProvider
 >;
 
 describe("getDnsProviderName", () => {
@@ -211,5 +220,61 @@ describe("verifyDomainOwnership dispatch", () => {
     expect(result).toBe(true);
     expect(r53VerifyMock).toHaveBeenCalledWith("example.com");
     expect(doVerifyMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("checkDnsProvider dispatch", () => {
+  const ORIGINAL_ENV = process.env.DNS_PROVIDER;
+
+  beforeEach(() => {
+    doCheckMock.mockReset();
+    r53CheckMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.DNS_PROVIDER;
+    } else {
+      process.env.DNS_PROVIDER = ORIGINAL_ENV;
+    }
+  });
+
+  it("delegates to digitalocean and returns its DnsHealth result unchanged", async () => {
+    process.env.DNS_PROVIDER = "digitalocean";
+    const doResult = {
+      ok: true as const,
+      provider: "digitalocean" as const,
+      detail: { domainCount: 3 },
+    };
+    doCheckMock.mockResolvedValue(doResult);
+
+    const result = await checkDnsProvider();
+
+    expect(result).toBe(doResult);
+    expect(doCheckMock).toHaveBeenCalledTimes(1);
+    expect(r53CheckMock).not.toHaveBeenCalled();
+  });
+
+  it("delegates to route53 and returns its DnsHealth result unchanged", async () => {
+    process.env.DNS_PROVIDER = "route53";
+    const r53Result = {
+      ok: true as const,
+      provider: "route53" as const,
+      detail: { hostedZoneCount: 2, pinnedZoneId: "Z123EXAMPLE" },
+    };
+    r53CheckMock.mockResolvedValue(r53Result);
+
+    const result = await checkDnsProvider();
+
+    expect(result).toBe(r53Result);
+    expect(r53CheckMock).toHaveBeenCalledTimes(1);
+    expect(doCheckMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates throw from getDnsProviderName on unknown DNS_PROVIDER", async () => {
+    process.env.DNS_PROVIDER = "cloudflare";
+    await expect(checkDnsProvider()).rejects.toThrow(/DNS_PROVIDER/);
+    expect(doCheckMock).not.toHaveBeenCalled();
+    expect(r53CheckMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/__tests__/route53.test.ts
+++ b/src/lib/__tests__/route53.test.ts
@@ -10,11 +10,13 @@ import {
   Route53Client,
   GetHostedZoneCommand,
   ListHostedZonesByNameCommand,
+  ListHostedZonesCommand,
   ListResourceRecordSetsCommand,
   ChangeResourceRecordSetsCommand,
 } from "@aws-sdk/client-route-53";
 
 import {
+  checkProvider,
   resolveHostedZoneId,
   setupDomainDNS,
   verifyDomainOwnership,
@@ -484,5 +486,85 @@ describe("resolveHostedZoneId", () => {
     expect(
       route53Mock.commandCalls(ListHostedZonesByNameCommand)
     ).toHaveLength(1);
+  });
+});
+
+describe("checkProvider (Route53)", () => {
+  beforeEach(() => {
+    __resetZoneIdCacheForTests();
+    delete process.env.AWS_HOSTED_ZONE_ID;
+  });
+
+  it("returns ok=true with detail.hostedZoneCount=1 + pinnedZoneId when AWS_HOSTED_ZONE_ID is set and GetHostedZone resolves", async () => {
+    process.env.AWS_HOSTED_ZONE_ID = "Z123EXAMPLE";
+    route53Mock.on(GetHostedZoneCommand).resolves({
+      HostedZone: {
+        Id: "/hostedzone/Z123EXAMPLE",
+        Name: "example.com.",
+        CallerReference: "ref",
+      },
+    });
+
+    const result = await checkProvider();
+
+    expect(result).toEqual({
+      ok: true,
+      provider: "route53",
+      detail: { hostedZoneCount: 1, pinnedZoneId: "Z123EXAMPLE" },
+    });
+    const calls = route53Mock.commandCalls(GetHostedZoneCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args[0].input).toEqual({ Id: "Z123EXAMPLE" });
+    // No account-level list when zone is pinned.
+    expect(route53Mock.commandCalls(ListHostedZonesCommand)).toHaveLength(0);
+  });
+
+  it("returns ok=true with detail.hostedZoneCount=N + pinnedZoneId=null when zone id is unset (lists account zones)", async () => {
+    route53Mock.on(ListHostedZonesCommand).resolves({
+      HostedZones: [
+        { Id: "/hostedzone/Z1", Name: "example.com.", CallerReference: "r1" },
+        { Id: "/hostedzone/Z2", Name: "example.org.", CallerReference: "r2" },
+        { Id: "/hostedzone/Z3", Name: "example.net.", CallerReference: "r3" },
+      ],
+    });
+
+    const result = await checkProvider();
+
+    expect(result).toEqual({
+      ok: true,
+      provider: "route53",
+      detail: { hostedZoneCount: 3, pinnedZoneId: null },
+    });
+    expect(route53Mock.commandCalls(ListHostedZonesCommand)).toHaveLength(1);
+    // No GetHostedZone call when zone is not pinned.
+    expect(route53Mock.commandCalls(GetHostedZoneCommand)).toHaveLength(0);
+  });
+
+  it("returns ok=false with httpStatusCode=403 on AccessDenied (and never serializes the raw error)", async () => {
+    process.env.AWS_HOSTED_ZONE_ID = "Z123EXAMPLE";
+    const err = Object.assign(new Error("access denied for route53:GetHostedZone"), {
+      name: "AccessDeniedException",
+      $metadata: { httpStatusCode: 403 },
+    });
+    route53Mock.on(GetHostedZoneCommand).rejects(err);
+
+    const result = await checkProvider();
+
+    expect(result).toEqual({
+      ok: false,
+      provider: "route53",
+      error: {
+        name: "AccessDeniedException",
+        message: "access denied for route53:GetHostedZone",
+        httpStatusCode: 403,
+      },
+    });
+
+    // Sanity: serialized form must not contain AWS access keys / Bearer
+    // tokens / secret accessors.
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toMatch(/AKIA[0-9A-Z]{16}/);
+    expect(serialized).not.toMatch(/Bearer\s+/);
+    expect(serialized).not.toContain("secretAccessKey");
   });
 });

--- a/src/lib/digitalocean.ts
+++ b/src/lib/digitalocean.ts
@@ -1,5 +1,5 @@
 import axios, { type AxiosInstance } from "axios";
-import type { DnsProviderRecord } from "./dns-provider";
+import type { DnsHealth, DnsProviderRecord } from "./dns-provider";
 
 const DO_API_BASE = "https://api.digitalocean.com/v2";
 
@@ -366,6 +366,58 @@ export async function verifyDomainOwnership(domain: string): Promise<boolean> {
   } catch (error: unknown) {
     console.error("Failed to verify domain ownership:", error);
     return false;
+  }
+}
+
+/**
+ * Read-only health probe used by `/api/health/dns` (admin Connections tab).
+ *
+ * Issues a single GET /v2/domains call so we verify both that
+ *   (a) `DO_API_TOKEN` is set, and
+ *   (b) the token is accepted by the API and can list account-level
+ *       resources.
+ *
+ * Errors are reduced to a `{ name, message, httpStatusCode }` whitelist
+ * — the raw axios error is never serialized because it transitively
+ * carries `response.config.headers.Authorization` (the `Bearer <token>`
+ * value), which would leak the token to the response payload.
+ */
+export async function checkProvider(): Promise<DnsHealth> {
+  if (!getApiToken()) {
+    return {
+      ok: false,
+      provider: "digitalocean",
+      error: {
+        name: "MissingToken",
+        message: "DO_API_TOKEN is not set",
+        httpStatusCode: null,
+      },
+    };
+  }
+
+  try {
+    const response = await getDoClient().get("/domains");
+    const domains = (response.data?.domains ?? []) as DODomain[];
+    return {
+      ok: true,
+      provider: "digitalocean",
+      detail: { domainCount: domains.length },
+    };
+  } catch (error: unknown) {
+    const axiosError = error as {
+      name?: string;
+      message?: string;
+      response?: { status?: number };
+    };
+    return {
+      ok: false,
+      provider: "digitalocean",
+      error: {
+        name: axiosError.name ?? "AxiosError",
+        message: axiosError.message ?? "Unknown error",
+        httpStatusCode: axiosError.response?.status ?? null,
+      },
+    };
   }
 }
 

--- a/src/lib/dns-provider.ts
+++ b/src/lib/dns-provider.ts
@@ -38,6 +38,39 @@ export interface DnsProviderRecord {
   description?: string;
 }
 
+/**
+ * Read-only health probe result from the active DNS provider.
+ *
+ * Each provider's `checkProvider()` returns this discriminated union so
+ * `/api/health/dns` can surface a single unified shape to the dashboard.
+ *
+ * Secret policy: the `error` branch never reflects raw error fields back
+ * to the client. Only `name`, `message`, and `httpStatusCode` are
+ * preserved — provider implementations build this whitelist in their
+ * own `checkProvider()` so SigV4 / Bearer headers attached to underlying
+ * SDK errors cannot leak.
+ */
+export type DnsHealth =
+  | {
+      ok: true;
+      provider: "digitalocean";
+      detail: { domainCount: number };
+    }
+  | {
+      ok: true;
+      provider: "route53";
+      detail: { hostedZoneCount: number; pinnedZoneId: string | null };
+    }
+  | {
+      ok: false;
+      provider: DnsProviderName;
+      error: {
+        name: string;
+        message: string;
+        httpStatusCode: number | null;
+      };
+    };
+
 const DEFAULT_PROVIDER: DnsProviderName = "digitalocean";
 const SUPPORTED_PROVIDERS: readonly DnsProviderName[] = [
   "digitalocean",
@@ -105,6 +138,29 @@ export async function verifyDomainOwnership(domain: string): Promise<boolean> {
       return digitalocean.verifyDomainOwnership(domain);
     case "route53":
       return route53.verifyDomainOwnership(domain);
+  }
+}
+
+/**
+ * Read-only health probe for the currently-active DNS provider. Used by
+ * `/api/health/dns` (admin Connections tab) to surface a single unified
+ * shape regardless of which provider the operator selected.
+ *
+ * Only the active provider is probed — checking a non-active provider
+ * would report token-absence as a false negative for credentials the
+ * operator never intended to configure.
+ *
+ * Throws (rather than returning `ok: false`) only when `DNS_PROVIDER`
+ * itself holds an unknown value — the route handler converts that to a
+ * generic 500 so misconfiguration is visible during operator setup.
+ */
+export async function checkDnsProvider(): Promise<DnsHealth> {
+  const provider = getDnsProviderName();
+  switch (provider) {
+    case "digitalocean":
+      return digitalocean.checkProvider();
+    case "route53":
+      return route53.checkProvider();
   }
 }
 

--- a/src/lib/route53.ts
+++ b/src/lib/route53.ts
@@ -23,6 +23,7 @@ import {
   Route53Client,
   GetHostedZoneCommand,
   ListHostedZonesByNameCommand,
+  ListHostedZonesCommand,
   ListResourceRecordSetsCommand,
   ChangeResourceRecordSetsCommand,
   type Change,
@@ -30,7 +31,7 @@ import {
   type RRType,
 } from "@aws-sdk/client-route-53";
 
-import type { DnsProviderRecord } from "./dns-provider";
+import type { DnsHealth, DnsProviderRecord } from "./dns-provider";
 
 /**
  * Build a fresh Route53 client per call. Mirrors the lazy pattern used in
@@ -329,4 +330,71 @@ function normalizeValue(value: string, type: RRType | undefined): string {
     return stripTrailingDot(value);
   }
   return value;
+}
+
+/**
+ * Read-only health probe used by `/api/health/dns` (admin Connections tab).
+ *
+ * Two paths depending on whether a hosted zone is pinned via env:
+ *   - `AWS_HOSTED_ZONE_ID` set -> issue a single `GetHostedZoneCommand`
+ *     for that exact zone. Verifies both that the zone exists and that
+ *     the configured AWS credentials have permission to read it.
+ *     Reported `hostedZoneCount` is `1` (the pinned zone) and
+ *     `pinnedZoneId` echoes the env value back so the dashboard can
+ *     render the operator's pin choice.
+ *   - `AWS_HOSTED_ZONE_ID` unset -> issue `ListHostedZonesCommand({})`
+ *     for an account-level visibility check. Reported `hostedZoneCount`
+ *     is the total returned in the first page (sufficient as a "can I
+ *     see anything?" probe; pagination is not exhausted because the
+ *     point is provider liveness, not exhaustive enumeration).
+ *     `pinnedZoneId` is `null` so the UI can show "auto-discover" mode.
+ *
+ * Errors are reduced to a `{ name, message, httpStatusCode }` whitelist
+ * — the raw AWS SDK error is never serialized because it transitively
+ * carries SigV4-signed request headers (the `Authorization` header
+ * includes `Credential=AKIA…/…`), which would leak the access key id
+ * to the response payload.
+ */
+export async function checkProvider(): Promise<DnsHealth> {
+  const pinnedZoneId = process.env.AWS_HOSTED_ZONE_ID;
+
+  try {
+    if (pinnedZoneId) {
+      await getRoute53Client().send(
+        new GetHostedZoneCommand({ Id: pinnedZoneId })
+      );
+      return {
+        ok: true,
+        provider: "route53",
+        detail: { hostedZoneCount: 1, pinnedZoneId },
+      };
+    }
+
+    const response = await getRoute53Client().send(
+      new ListHostedZonesCommand({})
+    );
+    return {
+      ok: true,
+      provider: "route53",
+      detail: {
+        hostedZoneCount: response.HostedZones?.length ?? 0,
+        pinnedZoneId: null,
+      },
+    };
+  } catch (error: unknown) {
+    const errObj = error as {
+      name?: string;
+      message?: string;
+      $metadata?: { httpStatusCode?: number };
+    };
+    return {
+      ok: false,
+      provider: "route53",
+      error: {
+        name: errObj.name ?? "Error",
+        message: errObj.message ?? "Unknown error",
+        httpStatusCode: errObj.$metadata?.httpStatusCode ?? null,
+      },
+    };
+  }
 }


### PR DESCRIPTION
## Summary

- Admin Dashboard 에 **Connections** 탭 신설 — SES (`/api/health/ses`) 와 활성 DNS provider (`/api/health/dns`) 의 헬스를 비파괴적으로 확인 (메일 전송·도메인 생성 없음)
- SESv2 `GetAccountCommand` 1콜로 sandbox 여부·송신 quota·EnforcementStatus 동시 진단; DNS 는 active provider 만 dispatch (DigitalOcean=`getDomains()`, Route53=pinned 면 `GetHostedZone`/없으면 `ListHostedZones`)
- 응답은 시크릿 미포함 (region/provider/count/error.{name,message,httpStatusCode} 만), `ok=true|false` 모두 HTTP 200

## Details

운영자가 SES/DNS 환경변수(`AWS_*`, `DO_API_TOKEN`, `AWS_HOSTED_ZONE_ID`, `DNS_PROVIDER`)를 설정한 뒤 정상 동작 가능한 상태인지 확인할 비파괴 경로가 없었다. 기존에는 도메인 추가·검증 메일 발송까지 가야만 IAM/토큰 누락이 드러나는 구조. 본 PR 은 admin 전용 경로로 한 번의 fetch 로 양 의존성 헬스를 보여준다.

설계 문서: `docs/plan/009-admin-connections-health-check.md`

### Auth wiring 결정 변경 (plan 의사결정 표 참조)

처음 `withAuth(GET)` 로 구현했으나 Next.js 15 의 route export validator 가 `withAuth` 의 generic 두번째 인자를 invalid 로 거부 (build 실패). 기존 모든 라우트가 inline `verifyJWT` 패턴을 쓰고 있어 일관성 차원에서 동일 패턴으로 전환. `withAuth` 시그니처의 Next.js 15 호환 리팩토링은 별도 PR 후속 트랙으로 기록.

### 응답 schema

```ts
type SesHealthResponse =
  | { ok: true; region; sandbox; sendingEnabled; enforcementStatus; sendQuota: { max24HourSend; maxSendRate; sentLast24Hours } | null }
  | { ok: false; region; error: { name; message; httpStatusCode | null } };

type DnsHealthResponse =
  | { ok: true; provider: "digitalocean"; detail: { domainCount } }
  | { ok: true; provider: "route53"; detail: { hostedZoneCount; pinnedZoneId } }
  | { ok: false; provider; error: { name; message; httpStatusCode | null } };
```

### Secret policy

AWS / axios 에러는 whitelist (`name`, `message`, `httpStatusCode`) 만 정규화 — `JSON.stringify(error)` 같은 광범위 직렬화 금지. 응답 직렬화 결과에 `AKIA*`, `Bearer *`, access key, DO token 패턴 부재를 단위 테스트로 강제.

## Changes

```
docs/plan/
└── 009-admin-connections-health-check.md       # 설계 + 의사결정 8건 + Phase 7개

src/lib/
├── dns-provider.ts                              # DnsHealth 타입 + checkDnsProvider() 디스패처
├── digitalocean.ts                              # checkProvider() (axios mock 친화)
├── route53.ts                                   # checkProvider() + ListHostedZonesCommand
└── __tests__/
    ├── digitalocean.test.ts                     # 신규 — 토큰 없음/happy/401
    ├── route53.test.ts                          # +3 케이스 (pinned/unpinned/403)
    └── dns-provider.test.ts                     # +3 디스패처 케이스 (격리 검증)

src/app/api/health/
├── ses/
│   ├── route.ts                                 # GET, inline verifyJWT, GetAccountCommand
│   └── __tests__/route.test.ts                  # 6 케이스
└── dns/
    ├── route.ts                                 # GET, inline verifyJWT, checkDnsProvider() 위임
    └── __tests__/route.test.ts                  # 8 케이스

src/components/
├── ConnectionsTab.tsx                           # 신규 — 카드 2개, 뱃지, refresh
├── Dashboard.tsx                                # connections 탭 등록 (맨 끝)
└── __tests__/ConnectionsTab.test.tsx            # 5 케이스 (loading/ok/error/refresh/secret-absent)

CLAUDE.md                                        # Connections 탭 + health 라우트 한 단락
README.md                                        # Features 한 줄
README.ko.md                                     # Features 한 줄
```

## Commits

- [`822bea5`](https://github.com/Orchemi/my-resend/commit/822bea5) docs(plan): add 009 admin connections health check plan
- [`059101c`](https://github.com/Orchemi/my-resend/commit/059101c) feat(dns-provider): add health check dispatcher and per-provider probe
- [`fbf975d`](https://github.com/Orchemi/my-resend/commit/fbf975d) feat(health-ses): add admin /api/health/ses route with GetAccount probe
- [`7682fb8`](https://github.com/Orchemi/my-resend/commit/7682fb8) feat(health-dns): add admin /api/health/dns route with provider dispatch
- [`3d20f40`](https://github.com/Orchemi/my-resend/commit/3d20f40) feat(connections): add Connections tab and document health endpoints

## Test plan

- [x] `npm run lint` — 0 warning
- [x] `npm run typecheck` — 0 error (`tsc --noEmit` baseline 유지, PR #16)
- [x] `npm test -- --runInBand --testPathIgnorePatterns='WaitlistSignup'` — 14 suites / 162 tests / 신규 28 케이스 모두 pass
- [x] `npm run build` — 21 routes 등록 (`/api/health/{ses,dns}` 포함)
- [x] DNS provider isolation: dispatcher 테스트가 양 provider mock 호출을 분리 (`expect(반대편).not.toHaveBeenCalled()`)
- [x] 시크릿 누설 0 (응답 직렬화 결과에 AWS access key / Bearer / DO token 패턴 부재 — 정규식 assertion)
- [x] 외부 hit 0 (모든 SDK/HTTP 호출 mock)

## Follow-ups

- `withAuth` 시그니처를 Next.js 15 route export validator 와 호환되게 리팩토링 (별도 PR)
- 자동 polling / alerting / webhook
- 다른 의존성 헬스 (Postgres connection, JWT secret presence)
- 도메인별 SES verification status 통합 (현 `getDomainVerificationStatus` 활용)
- Admin role 도입 후 `withAuth` → `withAdminAuth` 로 좁히기