### PR TITLE
DNS provider alignment: default to route53 + annotated env + Route53 setup guidance

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -52,8 +52,8 @@ ADMIN_PASSWORD=
 # DNS provider
 # ────────────────────────────────────────────────────────────────────────────
 
-# Active provider: "digitalocean" (default) or "route53".
-DNS_PROVIDER=digitalocean
+# Active provider: "route53" (default) or "digitalocean".
+DNS_PROVIDER=route53
 
 # DigitalOcean API token. CONDITIONAL — required when DNS_PROVIDER=digitalocean.
 # Create at: https://cloud.digitalocean.com/account/api/tokens

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -14,8 +14,8 @@
 
 ## External Services
 - **Amazon SES (v2)** - Email delivery service (`@aws-sdk/client-sesv2`)
-- **DigitalOcean API** - DNS management when `DNS_PROVIDER=digitalocean` (default)
-- **AWS Route53** - DNS management when `DNS_PROVIDER=route53` (`@aws-sdk/client-route-53`)
+- **AWS Route53** - DNS management when `DNS_PROVIDER=route53` (default, `@aws-sdk/client-route-53`)
+- **DigitalOcean API** - DNS management when `DNS_PROVIDER=digitalocean`
 - **AWS SDK v3** - Modern AWS client library (SES v2, Route53, IAM)
 
 ## Authentication & Security
@@ -72,7 +72,7 @@ Required environment variables:
 - `NEXTAUTH_URL` - Application URL
 - `NEXTAUTH_SECRET` - JWT signing secret
 - `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` - SES credentials
-- `DNS_PROVIDER` - `digitalocean` (default) or `route53`
-- `DO_API_TOKEN` - DigitalOcean API token (required when `DNS_PROVIDER=digitalocean`)
+- `DNS_PROVIDER` - `route53` (default) or `digitalocean`
 - `AWS_HOSTED_ZONE_ID` - Route53 hosted zone ID (optional, auto-discovered when unset)
+- `DO_API_TOKEN` - DigitalOcean API token (required when `DNS_PROVIDER=digitalocean`)
 - `ADMIN_EMAIL`, `ADMIN_PASSWORD` - Initial admin credentials

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ The schema lives in `database.sql`; there is no migration framework — apply on
 - `verifyDomain` swallows `AlreadyExistsException` and falls through to `GetEmailIdentity` to keep idempotency
 
 **DNS Provider Abstraction** (`src/lib/dns-provider.ts`):
-- Selected at runtime by `DNS_PROVIDER` (`digitalocean` | `route53`, default `digitalocean`)
+- Selected at runtime by `DNS_PROVIDER` (`route53` | `digitalocean`, default `route53`)
 - Exposes `setupDomainDNS(domain, dnsRecords)` and `verifyDomainOwnership(domain)`
 - Normalises every provider's native record shape to `DnsProviderRecord { type, name, value, ttl }` so consumers stay provider-agnostic
 - Unknown `DNS_PROVIDER` values throw (fail-fast) — silent fallback would mask typos
@@ -172,7 +172,7 @@ AWS_ACCESS_KEY_ID=...
 AWS_SECRET_ACCESS_KEY=...
 
 # DNS provider selection
-DNS_PROVIDER=digitalocean        # or "route53"; defaults to "digitalocean"
+DNS_PROVIDER=route53             # or "digitalocean"; defaults to "route53"
 
 # DigitalOcean (required when DNS_PROVIDER=digitalocean)
 DO_API_TOKEN=...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,8 +202,8 @@ cp .env.local.example .env.local
 
 **Conditional:**
 
-- `DO_API_TOKEN` when `DNS_PROVIDER=digitalocean` (default)
-- Route53 IAM policy when `DNS_PROVIDER=route53` (see [SETUP.md](./SETUP.md))
+- Route53 IAM policy when `DNS_PROVIDER=route53` (default — see [SETUP.md](./SETUP.md))
+- `DO_API_TOKEN` when `DNS_PROVIDER=digitalocean`
 
 See `CLAUDE.md § Environment Configuration` for the full key reference.
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -37,9 +37,9 @@ AWS_SECRET_ACCESS_KEY=
 ADMIN_EMAIL=admin@example.com
 ADMIN_PASSWORD=
 
-# DNS provider (default: digitalocean)
-DNS_PROVIDER=digitalocean
-DO_API_TOKEN=dop_v1_...
+# DNS provider (default: route53)
+DNS_PROVIDER=route53
+# DO_API_TOKEN=dop_v1_...   # required only when DNS_PROVIDER=digitalocean
 
 # Optional
 # AWS_HOSTED_ZONE_ID=...                        # route53 mode, optional

--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -128,8 +128,8 @@ src/
 
 ### DNS Provider Abstraction
 
-- `DNS_PROVIDER=digitalocean` (default) routes to DigitalOcean's DNS API via axios
-- `DNS_PROVIDER=route53` routes to AWS Route53 via the AWS SDK v3
+- `DNS_PROVIDER=route53` (default) routes to AWS Route53 via the AWS SDK v3
+- `DNS_PROVIDER=digitalocean` routes to DigitalOcean's DNS API via axios
 - Each provider implements the same shape (`setupDomainDNS`, `verifyDomainOwnership`, `checkProvider`); the dispatcher is in `src/lib/dns-provider.ts`
 - Provider isolation is verified by an integration suite (only one provider's client is exercised per `DNS_PROVIDER` mode)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -61,8 +61,8 @@ AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=your-aws-access-key
 AWS_SECRET_ACCESS_KEY=your-aws-secret-key
 
-# DNS provider 선택: digitalocean 또는 route53 (기본값: digitalocean)
-DNS_PROVIDER=digitalocean
+# DNS provider 선택: route53 또는 digitalocean (기본값: route53)
+DNS_PROVIDER=route53
 
 # DigitalOcean DNS (DNS_PROVIDER=digitalocean 일 때 필수)
 DO_API_TOKEN=your-digitalocean-api-token
@@ -125,7 +125,7 @@ npm run dev
 
 ## DNS Provider 셋업
 
-발송 도메인을 호스팅하는 provider 를 선택합니다. 활성 provider 는 `DNS_PROVIDER` 로 결정되며, 기본값은 upstream fork 와의 backward compatibility 를 위해 `digitalocean` 입니다. `DNS_PROVIDER` 가 알 수 없는 값이면 startup 시 throw — 오타가 silent 로 default 에 폴백되는 것을 방지합니다.
+발송 도메인을 호스팅하는 provider 를 선택합니다. 활성 provider 는 `DNS_PROVIDER` 로 결정되며, 기본값은 `route53` 입니다 — SES 운영자가 동일 AWS IAM 으로 Route53 권한을 함께 보유한 경우가 많기 때문. `DNS_PROVIDER` 가 알 수 없는 값이면 startup 시 throw — 오타가 silent 로 default 에 폴백되는 것을 방지합니다.
 
 ### 옵션 A — DigitalOcean DNS
 
@@ -288,7 +288,7 @@ npm run test:coverage       # 커버리지 리포트
 **Q: `DNS_PROVIDER` 가 startup 시 throw 합니다**
 
 - ✅ 허용 값은 `digitalocean` 과 `route53` 입니다. 알 수 없는 값은 의도적으로 거부되어 오타가 silent 로 default 에 폴백되는 것을 방지합니다
-- ✅ 변수를 설정하지 않으면 `digitalocean` (default) 으로 동작합니다
+- ✅ 변수를 설정하지 않으면 `route53` (default) 으로 동작합니다
 
 **Q: DigitalOcean DNS 자동화가 동작하지 않습니다**
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -61,7 +61,7 @@ AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=your-aws-access-key
 AWS_SECRET_ACCESS_KEY=your-aws-secret-key
 
-# DNS provider 선택 (기본값: digitalocean)
+# DNS provider 선택: digitalocean 또는 route53 (기본값: digitalocean)
 DNS_PROVIDER=digitalocean
 
 # DigitalOcean DNS (DNS_PROVIDER=digitalocean 일 때 필수)

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=your-aws-access-key
 AWS_SECRET_ACCESS_KEY=your-aws-secret-key
 
-# DNS provider selection: digitalocean or route53 (default: digitalocean)
-DNS_PROVIDER=digitalocean
+# DNS provider selection: route53 or digitalocean (default: route53)
+DNS_PROVIDER=route53
 
 # DigitalOcean DNS (required when DNS_PROVIDER=digitalocean)
 DO_API_TOKEN=your-digitalocean-api-token
@@ -125,7 +125,7 @@ Visit `http://localhost:3000` and log in with your admin credentials.
 
 ## DNS Provider Setup
 
-Pick whichever provider hosts your sending domain. The active provider is chosen by `DNS_PROVIDER`; default is `digitalocean` for backward compatibility with the upstream fork. Setting `DNS_PROVIDER` to an unknown value throws on startup so a typo can't silently fall back to the wrong provider.
+Pick whichever provider hosts your sending domain. The active provider is chosen by `DNS_PROVIDER`; default is `route53` because SES operators usually already hold a matching Route53 IAM scope under the same AWS account. Setting `DNS_PROVIDER` to an unknown value throws on startup so a typo can't silently fall back to the wrong provider.
 
 ### Option A — DigitalOcean DNS
 
@@ -288,7 +288,7 @@ For end-to-end verification against real AWS, send a test email from the dashboa
 **Q: `DNS_PROVIDER` throws at startup**
 
 - ✅ Allowed values are `digitalocean` and `route53`. Unknown values are rejected on purpose so a typo can't silently fall back to the default
-- ✅ Leave the variable unset to use `digitalocean` (default)
+- ✅ Leave the variable unset to use `route53` (default)
 
 **Q: DigitalOcean DNS automation not working**
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=your-aws-access-key
 AWS_SECRET_ACCESS_KEY=your-aws-secret-key
 
-# DNS provider selection (default: digitalocean)
+# DNS provider selection: digitalocean or route53 (default: digitalocean)
 DNS_PROVIDER=digitalocean
 
 # DigitalOcean DNS (required when DNS_PROVIDER=digitalocean)

--- a/SETUP.md
+++ b/SETUP.md
@@ -74,7 +74,24 @@ MyResend dispatches domain DNS setup to the provider chosen by `DNS_PROVIDER`. P
 
 1. **Route53** (default, `DNS_PROVIDER=route53`)
 
-   Reuse the AWS credentials from the SES step. Attach the following policy to the same IAM user — most SES operators already hold a Route53 scope under the same account. Actions correspond to the Route53 commands in `src/lib/route53.ts`:
+   Recommended when your AWS account already handles SES — the same IAM principal can manage Route53 without an extra credential, and the entire flow (send + DNS) stays under one audit trail.
+
+   **a. Create a Route53 hosted zone for your sending domain**
+
+   - AWS Console → Route53 → Hosted zones → **Create hosted zone**.
+   - Domain name: the apex you'll send from (e.g. `example.com`). Subdomains like `mail.example.com` can be served either from a dedicated subzone or from the apex zone — MyResend's `AWS_HOSTED_ZONE_ID` auto-discovery walks up to parent zones, so the apex usually suffices.
+   - Type: **Public hosted zone**.
+   - Take note of the 4 NS records AWS assigns to the new zone — you'll need them in step (b).
+
+   **b. Delegate the domain at your registrar**
+
+   At your domain registrar (Namecheap, GoDaddy, Cloudflare-as-registrar, Gandi, etc.), replace the existing NS records for the domain with the 4 NS values from step (a). DNS propagation can take from minutes to 48 hours depending on the prior TTL. Until delegation completes, SES verification TXT records that MyResend writes into Route53 won't be visible from the public internet — domain verification stays "pending".
+
+   If the domain already lives in Route53 (e.g. registered through Route53 Domains, or a prior project), skip (a) and (b).
+
+   **c. Attach the Route53 IAM policy**
+
+   Add this statement to the IAM user from the SES step above. Actions map 1:1 to the Route53 commands MyResend issues in `src/lib/route53.ts`:
 
    ```json
    {
@@ -97,11 +114,20 @@ MyResend dispatches domain DNS setup to the provider chosen by `DNS_PROVIDER`. P
    }
    ```
 
-   `AWS_HOSTED_ZONE_ID` is optional — if unset, MyResend auto-discovers the hosted zone for the sending domain via `ListHostedZonesByName`, walking up to parent zones.
+   `route53:GetChange` is not invoked by MyResend itself today, but is included so that you can inspect change propagation from the AWS Console or CLI without re-editing the policy.
+
+   **d. (Optional) Pin a specific hosted zone with `AWS_HOSTED_ZONE_ID`**
+
+   - **Leave unset** (recommended for single-zone or apex-plus-subdomain setups). MyResend calls `ListHostedZonesByName` for the sending domain and walks up to parent zones if needed — e.g. adding `mail.example.com` resolves to the `example.com` hosted zone automatically. Auto-discovery results are memoised per process.
+   - **Set explicitly** (`AWS_HOSTED_ZONE_ID=Z0123456789ABCDEFGHIJ`) when you run multiple Route53 hosted zones and want MyResend pinned to one specific zone — for example when several teams share an AWS account and only one of them owns the zone MyResend should touch.
+
+   **e. Verify**
+
+   After deploy, the admin **Connections** tab's DNS card calls `/api/health/dns` → `route53:ListHostedZones`. A green card confirms the IAM policy, region, and credentials are wired correctly. If the card is red, the response body identifies the failing action.
 
 2. **DigitalOcean** (`DNS_PROVIDER=digitalocean`)
 
-   Create an API token at [DigitalOcean → API → Tokens](https://cloud.digitalocean.com/account/api/tokens) with read+write scope and add the target domains to DO's DNS management. Set `DO_API_TOKEN`.
+   Use this when your DNS already lives at DigitalOcean and you don't want to migrate to Route53. Create an API token at [DigitalOcean → API → Tokens](https://cloud.digitalocean.com/account/api/tokens) with read+write scope, add the target domains under DO's DNS management, and set `DO_API_TOKEN`.
 
 ## 2. Environment Configuration
 
@@ -242,13 +268,18 @@ Value: 10 inbound-smtp.us-east-1.amazonaws.com
 
 3. **`/api/health/dns` returns `ok: false`**
 
-   - DigitalOcean: regenerate `DO_API_TOKEN` with read+write scope.
-   - Route53: confirm the Route53 policy is attached. If using a parent-zone-only setup, leave `AWS_HOSTED_ZONE_ID` unset so auto-discovery runs.
+   - **Route53** (default):
+     - Confirm the IAM policy from § 1 is attached to the same user as the SES credentials. The single most common cause is `route53:ListHostedZones` missing — the health probe calls it first.
+     - If you maintain multiple hosted zones and the probe fails on `GetHostedZone`, set `AWS_HOSTED_ZONE_ID` explicitly to pin one zone. Otherwise leave it unset so auto-discovery walks parent zones.
+     - Region is irrelevant — Route53 is global. `AWS_REGION` only affects SES.
+     - Cross-account scenarios (sending from account A, DNS in account B) are not supported by a single IAM user; either move DNS into the SES account or run two separate MyResend deploys.
+   - **DigitalOcean**: regenerate `DO_API_TOKEN` with read+write scope. Tokens lacking write scope can pass the connection check but fail at `setupDomainDNS`.
 
 4. **Domain verification stays "pending"**
 
    - DNS propagation can take minutes to hours. Confirm the records visible in your DNS provider match what the Domains tab generated.
    - DKIM tokens flow back into the DNS records on a retry — the first apply might omit them until SES returns the tokens.
+   - **Route53 specifically**: if the records appear in the AWS Console but `dig` from the public internet returns nothing, your registrar still points the domain at the previous nameservers. Re-check the NS delegation from § 1 step (b).
 
 5. **API key authentication fails**
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -72,13 +72,9 @@ MyResend uses raw `pg` queries (no ORM) and bootstraps from a single SQL file. A
 
 MyResend dispatches domain DNS setup to the provider chosen by `DNS_PROVIDER`. Pick one:
 
-1. **DigitalOcean** (default, `DNS_PROVIDER=digitalocean`)
+1. **Route53** (default, `DNS_PROVIDER=route53`)
 
-   Create an API token at [DigitalOcean → API → Tokens](https://cloud.digitalocean.com/account/api/tokens) with read+write scope and add the target domains to DO's DNS management. Set `DO_API_TOKEN`.
-
-2. **Route53** (`DNS_PROVIDER=route53`)
-
-   Reuse the AWS credentials from the SES step. Attach the following policy to the same IAM user. Actions correspond to the Route53 commands in `src/lib/route53.ts`:
+   Reuse the AWS credentials from the SES step. Attach the following policy to the same IAM user — most SES operators already hold a Route53 scope under the same account. Actions correspond to the Route53 commands in `src/lib/route53.ts`:
 
    ```json
    {
@@ -103,6 +99,10 @@ MyResend dispatches domain DNS setup to the provider chosen by `DNS_PROVIDER`. P
 
    `AWS_HOSTED_ZONE_ID` is optional — if unset, MyResend auto-discovers the hosted zone for the sending domain via `ListHostedZonesByName`, walking up to parent zones.
 
+2. **DigitalOcean** (`DNS_PROVIDER=digitalocean`)
+
+   Create an API token at [DigitalOcean → API → Tokens](https://cloud.digitalocean.com/account/api/tokens) with read+write scope and add the target domains to DO's DNS management. Set `DO_API_TOKEN`.
+
 ## 2. Environment Configuration
 
 1. Copy the example environment file:
@@ -122,10 +122,10 @@ MyResend dispatches domain DNS setup to the provider chosen by `DNS_PROVIDER`. P
    AWS_ACCESS_KEY_ID=AKIA...
    AWS_SECRET_ACCESS_KEY=...
 
-   # DNS provider (default: digitalocean)
-   DNS_PROVIDER=digitalocean
-   DO_API_TOKEN=dop_v1_...        # required when DNS_PROVIDER=digitalocean
-   # AWS_HOSTED_ZONE_ID=...       # optional, route53 mode
+   # DNS provider (default: route53)
+   DNS_PROVIDER=route53
+   # AWS_HOSTED_ZONE_ID=...       # optional, route53 auto-discovers when unset
+   # DO_API_TOKEN=dop_v1_...      # required only when DNS_PROVIDER=digitalocean
 
    # Security
    NEXTAUTH_SECRET=               # 64+ char random — `openssl rand -base64 64`

--- a/src/lib/__tests__/dns-provider.test.ts
+++ b/src/lib/__tests__/dns-provider.test.ts
@@ -60,9 +60,9 @@ describe("getDnsProviderName", () => {
     }
   });
 
-  it("returns 'digitalocean' when DNS_PROVIDER is unset (backward compat)", () => {
+  it("returns 'route53' when DNS_PROVIDER is unset (default)", () => {
     delete process.env.DNS_PROVIDER;
-    expect(getDnsProviderName()).toBe("digitalocean");
+    expect(getDnsProviderName()).toBe("route53");
   });
 
   it("returns 'digitalocean' when DNS_PROVIDER='digitalocean'", () => {
@@ -87,7 +87,7 @@ describe("getDnsProviderName", () => {
 
   it("treats empty string as unset and falls back to default", () => {
     process.env.DNS_PROVIDER = "";
-    expect(getDnsProviderName()).toBe("digitalocean");
+    expect(getDnsProviderName()).toBe("route53");
   });
 });
 

--- a/src/lib/dns-provider.ts
+++ b/src/lib/dns-provider.ts
@@ -6,8 +6,8 @@
  * directly. The active provider is selected by the `DNS_PROVIDER` env var.
  *
  * Supported providers:
- *   - `digitalocean` (default — backward compatible with upstream fork)
- *   - `route53`
+ *   - `route53` (default — SES operators typically already hold Route53 IAM)
+ *   - `digitalocean`
  *
  * Adding a new provider: implement `setupDomainDNS` and
  * `verifyDomainOwnership` in a new module, then extend the union type and
@@ -71,7 +71,7 @@ export type DnsHealth =
       };
     };
 
-const DEFAULT_PROVIDER: DnsProviderName = "digitalocean";
+const DEFAULT_PROVIDER: DnsProviderName = "route53";
 const SUPPORTED_PROVIDERS: readonly DnsProviderName[] = [
   "digitalocean",
   "route53",
@@ -80,7 +80,8 @@ const SUPPORTED_PROVIDERS: readonly DnsProviderName[] = [
 /**
  * Resolve the active DNS provider from `DNS_PROVIDER`.
  *
- * - Unset / empty -> `digitalocean` (backward compat).
+ * - Unset / empty -> `route53` (default — SES operators usually already
+ *   hold the matching Route53 IAM scope).
  * - Case-insensitive match against the supported set.
  * - Unknown value -> throw (fail-fast: catches typos rather than silently
  *   falling back to the default and surprising the operator).


### PR DESCRIPTION
## Summary

- `DNS_PROVIDER` default 를 `digitalocean` → `route53` 으로 전환 (SES 운영자가 동일 AWS IAM 으로 Route53 권한 함께 보유 케이스 多 — backward-compat 명분이 fork 신규 운영자에게 적용되지 않음)
- README env 예시 주석에 허용 값 두 개 (`route53` / `digitalocean`) 모두 명시
- `SETUP.md` Route53 단락을 5단계 절차로 펼치고 트러블슈팅 보강

Closes #31

## Details

PR #30 (Tier 3) 후속. 진행 중 사용자 컨텍스트 (SES + Route53 IAM 동일 AWS 계정) 와 `DNS_PROVIDER` default 가 어긋난다는 관찰에서 출발.

**Default 변경 안전성 검증**: 코드 grep 결과 default 가정에 의존하는 후속 동작 0건 — `src/lib/dns-provider.ts:74` 의 `DEFAULT_PROVIDER` 단일 상수만이 default 결정 지점. 모든 디스패치 / UI / health route 가 `getDnsProviderName()` 결과만 보고 switch 하므로 default 값과 무관.

기존 plan 002 의 backward-compat 결정 (upstream eibrahim/freeresend 마이그레이션 사용자 보호) 은 my-resend fork 신규 운영자에게 적용되지 않는 이력 기반 결정 — 본 PR 에서 재의사결정 후 전환.

**SETUP.md Route53 단락 5단계로 펼침**:
1. Hosted zone 생성 (AWS Console 경로, NS 4개 메모)
2. 도메인 등록기관에서 NS 위임 (가장 빈번하게 누락되는 단계)
3. IAM 정책 첨부 (`route53:GetChange` 가 SDK 미호출이지만 콘솔/CLI propagation 조회 호환 위해 포함된 이유 명시)
4. `AWS_HOSTED_ZONE_ID` 자동 탐지 vs 명시 핀 가이드
5. Connections 탭 DNS 카드로 검증

**트러블슈팅 #3 (`/api/health/dns` ok:false), #4 (verification pending)** 에 Route53 흔한 함정 (region 무관성, cross-account 미지원, NS 위임 누락) 보강.

## Changes

```
src/lib/
├── dns-provider.ts                          # DEFAULT_PROVIDER + doc comment
└── __tests__/dns-provider.test.ts           # unset / empty 케이스 갱신
.env.local.example                            # placeholder + 주석
README.md, README.ko.md                       # env 주석 + 본문 + FAQ 갱신
SETUP.md                                      # Route53 5단계 + 트러블슈팅 보강
DEPLOYMENT.md                                 # env 예시 주석
PROJECT_SUMMARY.md                            # DNS provider 우선순위 swap
CLAUDE.md                                     # default 표기
CONTRIBUTING.md                               # 환경변수 안내 순서
.kiro/steering/tech.md                        # External Services 우선순위 + DNS_PROVIDER 라인
```

## Commits

- [`d475d47`](https://github.com/Orchemi/my-resend/commit/d475d47) docs(readme): annotate DNS_PROVIDER alternative value in env example
- [`75b9ef6`](https://github.com/Orchemi/my-resend/commit/75b9ef6) chore(dns): switch default DNS_PROVIDER from digitalocean to route53
- [`572a513`](https://github.com/Orchemi/my-resend/commit/572a513) docs(setup): expand Route53 setup with hosted zone delegation and troubleshooting

## Test plan

- [x] CI 4단 (lint / typecheck / test 162 — 변경된 `dns-provider.test.ts` 의 unset / empty 케이스 포함 통과 / build)
- [x] 코드 grep 결과 "digitalocean 가정" 의존 0건
- [x] 모든 문서의 default 표기가 일관되게 `route53` 로 갱신