### PR TITLE
Korean translation: SETUP.ko.md / DEPLOYMENT.ko.md / PROJECT_SUMMARY.ko.md with paired cross-links

### DIFF
--- a/DEPLOYMENT.ko.md
+++ b/DEPLOYMENT.ko.md
@@ -1,0 +1,176 @@
+# MyResend 배포 가이드
+
+> 🌐 **언어**: [English](./DEPLOYMENT.md) · **한국어**
+
+MyResend 는 표준 Next.js 15 애플리케이션입니다. Node 20+ 를 실행할 수 있고 PostgreSQL 데이터베이스에 접근 가능한 호스트면 어디서든 동작합니다. 이 가이드는 지원되는 배포 옵션을 나란히 나열하고, 모든 옵션에 공통되는 단계도 함께 정리합니다.
+
+로컬 첫 실행 셋업은 [SETUP.ko.md](./SETUP.ko.md) 를 참고하세요.
+
+## 1. 사전 준비 (모든 옵션 공통)
+
+- 배포 환경에서 접근 가능한 PostgreSQL 14+ 데이터베이스 (관리형 또는 self-hosted)
+- AWS SES production access (검증된 수신자에게만 테스트한다면 sandbox 도 가능)
+- [SETUP.ko.md](./SETUP.ko.md) 의 SES v2 정책을 가진 IAM 사용자 (`DNS_PROVIDER=route53` 이면 Route53 정책도 함께)
+- `DNS_PROVIDER=digitalocean` 일 때는 DigitalOcean API 토큰
+- 커스텀 도메인 (선택이나 일반적 — sandbox 가 아닌 주소로 발송하려면 필수)
+
+## 2. 데이터베이스
+
+MyResend 는 단일 SQL 파일에서 부트스트랩합니다 (마이그레이션 프레임워크 없음). PostgreSQL 호환 서비스면 어떤 것이든 동작합니다 — 데이터베이스를 프로비저닝하고 connection string 을 `DATABASE_URL` 에 넣은 뒤:
+
+```bash
+psql "$DATABASE_URL" -f database.sql
+```
+
+스크립트는 idempotent (`CREATE TABLE IF NOT EXISTS`) 라 기존 데이터베이스에서도 재실행 안전합니다.
+
+## 3. 환경 변수
+
+`CLAUDE.md § Environment Configuration` 에 정리된 키들을 설정합니다 (`.env.local.example` 에도 동일 집합). 배포 형태에 민감한 키는 다음과 같습니다:
+
+```bash
+# 필수
+DATABASE_URL=postgresql://user:pass@host:5432/my_resend
+NEXTAUTH_URL=https://your-domain.example.com    # public origin
+NEXTAUTH_SECRET=                                # 64자 이상 랜덤
+AWS_REGION=us-east-1
+AWS_ACCESS_KEY_ID=AKIA...
+AWS_SECRET_ACCESS_KEY=
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=
+
+# DNS provider (기본값: route53)
+DNS_PROVIDER=route53
+# DO_API_TOKEN=dop_v1_...   # DNS_PROVIDER=digitalocean 일 때만 필수
+
+# 선택
+# AWS_HOSTED_ZONE_ID=...                        # route53 모드, 선택
+# CRON_SECRET=                                  # cron endpoint 헤더
+```
+
+`.env.local` 이나 실제 시크릿이 담긴 파일은 절대 commit 하지 않습니다. `.env.local.example` 만 git 추적 대상이며 placeholder 만 포함합니다.
+
+## 4. 배포 옵션
+
+MyResend 는 플랫폼 lock-in 이 없습니다. 아래 옵션은 우선순위 없이 나열되어 있으니 기존 인프라에 맞는 것을 고르세요.
+
+### 옵션 A: Docker
+
+```bash
+# 빌드
+docker build -t my-resend .
+
+# 실행
+docker run -d --name my-resend \
+  -p 3000:3000 \
+  --env-file .env.local \
+  my-resend
+```
+
+번들된 `docker-compose.yml` 은 애플리케이션 서비스와 함께 첫 부팅 시 `database.sql` 로 초기화되는 선택적 (주석 처리된) Postgres 서비스도 제공합니다.
+
+### 옵션 B: Dokku
+
+```bash
+# Dokku 호스트에서
+dokku apps:create my-resend
+dokku postgres:create my-resend-db
+dokku postgres:link my-resend-db my-resend
+dokku config:set my-resend \
+  AWS_REGION=us-east-1 \
+  AWS_ACCESS_KEY_ID=... \
+  AWS_SECRET_ACCESS_KEY=... \
+  NEXTAUTH_SECRET=... \
+  ADMIN_EMAIL=admin@example.com \
+  ADMIN_PASSWORD=... \
+  DNS_PROVIDER=digitalocean \
+  DO_API_TOKEN=...
+
+# 워크스테이션에서
+git remote add dokku dokku@your-dokku-host:my-resend
+git push dokku develop:main
+```
+
+### 옵션 C: Coolify / CapRover / 기타 PaaS
+
+Dockerfile 을 받는 container-aware PaaS 면 모두 호환됩니다. 본 저장소를 가리키고, PaaS 대시보드에서 환경 변수를 설정한 뒤, 포함된 `Dockerfile` 로 빌드하게 합니다.
+
+### 옵션 D: Fly.io
+
+```bash
+fly launch --no-deploy        # fly.toml 생성
+fly secrets set DATABASE_URL=... NEXTAUTH_SECRET=... \
+                AWS_REGION=... AWS_ACCESS_KEY_ID=... \
+                AWS_SECRET_ACCESS_KEY=... ADMIN_EMAIL=... \
+                ADMIN_PASSWORD=... DNS_PROVIDER=... DO_API_TOKEN=...
+fly deploy
+```
+
+데이터베이스는 Fly Postgres (`fly postgres create`) 를 프로비저닝하거나, 외부 관리형 Postgres 를 `DATABASE_URL` 로 가리키면 됩니다.
+
+### 옵션 E: Vercel
+
+```bash
+vercel login
+vercel link
+vercel env add DATABASE_URL          # 각 변수마다 반복
+vercel --prod
+```
+
+주의:
+- Vercel 의 serverless function 은 수명이 짧아 장기 실행 작업에는 적합하지 않습니다 (MyResend 에는 그런 작업이 없습니다).
+- Postgres 는 외부에서 프로비저닝하세요 (Neon, RDS 등) — Vercel 은 데이터베이스를 호스팅하지 않습니다.
+
+### 옵션 F: Kubernetes
+
+저장소의 `k8s/` 디렉터리에 샘플 매니페스트가 포함되어 있습니다 (turn-key 배포가 아니라 시작점 reference 로 사용하세요). 처음부터 배포하려면 `Dockerfile` 로 이미지를 빌드해 본인 레지스트리에 push 하고, `DATABASE_URL` 과 AWS credential 을 Secret 으로 연결한 Deployment + Service + Ingress 매니페스트를 작성합니다.
+
+## 5. 커스텀 도메인과 TLS
+
+위 플랫폼들 대부분은 TLS 를 자동 종료해줍니다 (Vercel, Fly.io, Let's Encrypt 가 붙은 Dokku, Coolify, cert-manager 가 붙은 Kubernetes). 도메인이 배포를 가리키게 된 다음:
+
+1. `NEXTAUTH_URL` 을 public origin 으로 설정합니다.
+2. 새 값이 반영되도록 재배포 또는 재시작합니다.
+
+## 6. 배포 후 체크리스트
+
+1. `https://your-domain.example.com` 에 접속해 랜딩 페이지가 표시되는지 확인합니다.
+2. admin 사용자 시드: `curl -X POST https://your-domain.example.com/api/setup`. 재실행은 idempotent 하므로 안전합니다.
+3. `ADMIN_EMAIL` / `ADMIN_PASSWORD` 로 로그인합니다.
+4. **Connections** 탭을 열어 두 카드 모두 `ok: true` 인지 확인합니다. 실패 시 응답 body 가 누락된 IAM 액션 또는 무효 토큰을 알려줍니다.
+5. **Domains** 탭에서 실제 도메인을 추가하고 SES verification + DKIM 활성화를 기다립니다.
+6. 검증된 도메인에 대해 API key 를 발급하고 테스트 메일을 보냅니다.
+
+## 7. 운영 노트
+
+### CI Gate
+
+`.github/workflows/ci.yml` 이 모든 PR 에서 `lint → typecheck → test → build` 를 실행합니다. 배포 artifact 는 동일한 `npm run build` 결과물이므로, 초록 CI 는 배포 빌드 성공을 보증합니다.
+
+### 테스트의 외부 호출
+
+Jest 슈트는 모든 외부 SDK 호출을 mock 합니다 (AWS 는 `aws-sdk-client-mock`, axios 는 `jest.mock`). 실제 AWS, DigitalOcean, SMTP 를 절대 hit 하지 않습니다. 동작 검증의 source of truth 로 Jest 를 신뢰하세요 — `npm test -- src/lib/__tests__/ses` 가 네트워크 없이 SES 경로를 end-to-end 로 실행합니다.
+
+### 스케일링
+
+- 웹 티어는 `users`, `domains`, `api_keys`, `email_logs` 테이블 뒤에서 stateless 입니다. Horizontal scaling 은 단순합니다 — 앞단에 load balancer 만 두면 됩니다.
+- AWS SES 는 account-level 발송 quota 를 가집니다 (**Connections** 탭이 `GetAccount` 로 표시). 대량 발송 전 quota 증액을 요청하세요.
+- Route53 은 rate-limit 이 있습니다 (hosted zone 당 5 changes/second). MyResend 는 도메인별로 레코드 변경을 직렬화하지만, 대량 import 는 페이스 조절이 필요합니다.
+
+### 업데이트
+
+Git 기반 배포 (Dokku, Fly.io, Vercel + GitHub 연동) 는 추적 브랜치에 push 하면 호스트가 재빌드합니다. Docker 기반 배포는 이미지를 재빌드하고 컨테이너를 재시작합니다. 스키마를 변경한 변경분을 pull 한 뒤에는 항상 `psql "$DATABASE_URL" -f database.sql` 을 실행하세요.
+
+## 8. 보안 체크리스트
+
+- [ ] `NEXTAUTH_SECRET` 이 64자 이상의 랜덤 데이터인지
+- [ ] `AWS_*` credential 이 MyResend 가 사용하는 SES + Route53 액션으로만 한정되어 있는지 (정확한 정책은 [SETUP.ko.md](./SETUP.ko.md) 참조)
+- [ ] 시크릿이 플랫폼의 secret manager (Vercel env, Dokku config, Fly secrets, Kubernetes Secrets) 에 있고 commit 파일에는 없는지
+- [ ] TLS 가 end-to-end 로 강제되는지. 위 대부분의 플랫폼은 기본값으로 처리
+- [ ] 데이터베이스 연결이 provider 가 제공하는 경우 TLS 를 사용하는지 (connection string 에 `sslmode=require`)
+- [ ] `/api/cron/*` endpoint 를 노출한다면 `CRON_SECRET` 이 설정되었는지
+
+## 9. 지원
+
+- 버그 리포트: [Orchemi/my-resend issues](https://github.com/Orchemi/my-resend/issues)
+- Attribution 과 upstream divergence boundary: [NOTICE](./NOTICE) 참조

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,5 +1,7 @@
 # MyResend Deployment Guide
 
+> 🌐 **Languages**: **English** · [한국어](./DEPLOYMENT.ko.md)
+
 MyResend is a standard Next.js 15 application. Any host that can run Node 20+ and reach a PostgreSQL database works. This guide lists the supported deployment options side by side, plus the steps that are common to all of them.
 
 For local first-run setup, see [SETUP.md](./SETUP.md).

--- a/PROJECT_SUMMARY.ko.md
+++ b/PROJECT_SUMMARY.ko.md
@@ -1,0 +1,207 @@
+# MyResend - 프로젝트 요약
+
+> 🌐 **언어**: [English](./PROJECT_SUMMARY.md) · **한국어**
+
+## 개요
+
+MyResend 는 self-hosted, Resend 호환 메일 게이트웨이입니다. Next.js 15 위에 구축되었으며, AWS SDK v3 (`@aws-sdk/client-sesv2`) 를 통해 Amazon SES 로 메일을 발송하고, 도메인 DNS 레코드는 DigitalOcean DNS 또는 AWS Route53 으로 관리합니다 — 활성 provider 는 런타임에 `DNS_PROVIDER` 환경 변수로 선택합니다.
+
+## 아키텍처
+
+### 백엔드 서비스
+
+- **Next.js 15 API Routes** — `src/app/api/` 아래 RESTful endpoint
+- **PostgreSQL** — `database.sql` 의 스키마에 대해 raw `pg` 쿼리 사용 (ORM 없음, 마이그레이션 프레임워크 없음)
+- **AWS SDK v3** — 발송용 SES v2 (`@aws-sdk/client-sesv2`), DNS 용 Route53 (`@aws-sdk/client-route-53`), 필요한 경우 IAM (`@aws-sdk/client-iam`)
+- **DNS provider dispatch** — `src/lib/dns-provider.ts` 가 DigitalOcean (`src/lib/digitalocean.ts`) 또는 Route53 (`src/lib/route53.ts`) 로 디스패치
+- **JWT 인증** — admin 세션은 `NEXTAUTH_SECRET` 으로 서명, 외부 클라이언트는 `mrs_<id>_<secret>` API key
+
+### 프론트엔드
+
+- **Next.js 15 + React 19** — App Router 대시보드 (dev 에서 Turbopack)
+- **Tailwind CSS v4** — 스타일링
+- **TypeScript 5** — strict mode, CI 가 `tsc --noEmit` 0-error baseline 을 강제
+
+## 파일 구조
+
+```
+src/
+├── app/
+│   ├── api/
+│   │   ├── auth/           # 인증 endpoint
+│   │   ├── domains/        # 도메인 관리
+│   │   ├── api-keys/       # API key 관리
+│   │   ├── emails/         # 메일 발송 & 로그
+│   │   ├── webhooks/       # SES webhook 핸들러
+│   │   ├── health/
+│   │   │   ├── ses/        # SES 헬스 프로브 (GetAccount)
+│   │   │   └── dns/        # DNS provider 헬스 프로브
+│   │   ├── waitlist/       # 대기자 명단 등록 endpoint
+│   │   ├── stats/          # Stats API
+│   │   ├── cron/           # 주기적 stats push
+│   │   └── setup/          # 초기 admin 시드
+│   ├── login/
+│   ├── pricing/
+│   ├── layout.tsx          # AuthProvider 가 붙은 root layout
+│   └── page.tsx            # 메인 앱 entry
+├── components/
+│   ├── Dashboard.tsx        # 탭 컨테이너
+│   ├── LandingPage.tsx      # 미인증 랜딩
+│   ├── DomainsTab.tsx       # 도메인 관리 UI
+│   ├── ApiKeysTab.tsx       # API key 관리 UI
+│   ├── EmailLogsTab.tsx     # 메일 로그
+│   └── ConnectionsTab.tsx   # SES + DNS 헬스 카드
+├── contexts/
+│   └── AuthContext.tsx
+└── lib/
+    ├── api.ts               # 프론트엔드 API 클라이언트
+    ├── auth.ts              # JWT + bcrypt 사용자 인증
+    ├── api-keys.ts          # API key 발급 / 검증
+    ├── domains.ts           # 도메인 operations
+    ├── ses.ts               # AWS SES v2 연동
+    ├── dns-provider.ts      # DNS provider 디스패처
+    ├── digitalocean.ts      # DigitalOcean DNS 구현
+    ├── route53.ts           # Route53 DNS 구현
+    ├── database.ts          # PostgreSQL 클라이언트 + interfaces
+    ├── middleware.ts        # API 미들웨어 (JWT verify 등)
+    └── notifications.ts     # 대기자 명단 / admin 알림
+```
+
+## 데이터베이스 스키마
+
+### 테이블
+
+- **users** — admin 사용자 계정
+- **domains** — 발송 도메인
+- **api_keys** — 검증된 도메인마다 발급되는 `mrs_<id>_<secret>`
+- **email_logs** — 모든 발송 기록
+- **webhook_events** — SES 전송 이벤트
+- **waitlist_signups** — hosted-version 대기자 명단 (기본 비활성)
+
+### 핵심 속성
+
+- UUID primary key
+- 외래 키와 자주 사용되는 query path 에 인덱스
+- SES 응답 detail 용 JSON 컬럼
+- 스키마 부트스트랩은 idempotent — `CREATE TABLE IF NOT EXISTS` 일관 사용. `psql "$DATABASE_URL" -f database.sql` 로 적용.
+
+## API Endpoint
+
+### 인증
+
+- `POST /api/auth/login` — admin 로그인
+- `GET /api/auth/me` — 현재 사용자
+
+### 도메인 관리
+
+- `GET /api/domains` — 도메인 목록
+- `POST /api/domains` — 도메인 추가 (DNS 레코드 생성, 활성 DNS provider 에 디스패치, SES 에 등록)
+- `DELETE /api/domains/{id}` — 도메인 제거
+- `POST /api/domains/{id}/verify` — SES verification 상태 재확인
+
+### API Key
+
+- `GET /api/api-keys` — API key 목록
+- `POST /api/api-keys` — 새 key 생성 (검증된 도메인에 대해서만)
+- `DELETE /api/api-keys/{id}` — key 삭제
+
+### 메일 operations (Resend 호환)
+
+- `POST /api/emails` — 메일 발송
+- `GET /api/emails/logs` — 메일 이력
+- `GET /api/emails/{id}` — 메일 상세
+
+### 시스템
+
+- `GET /api/health/ses` — SES 헬스 (admin JWT, `GetAccount` 호출)
+- `GET /api/health/dns` — DNS provider 헬스 (admin JWT, provider 별 프로브 호출)
+- `POST /api/setup` — `ADMIN_EMAIL` / `ADMIN_PASSWORD` 로 admin 사용자 시드
+- `POST /api/webhooks/ses` — SES 이벤트 ingest
+
+## 핵심 연동
+
+### AWS SES (v2)
+
+- 도메인 identity 생성과 verification
+- DKIM 속성 관리
+- 메일 발송 (`SendEmail` / configuration set)
+- 계정 헬스 프로브 (`GetAccount`)
+- Webhook 이벤트 ingestion
+
+### DNS Provider 추상화
+
+- `DNS_PROVIDER=route53` (기본값) — AWS SDK v3 를 통해 AWS Route53 로 라우팅
+- `DNS_PROVIDER=digitalocean` — axios 를 통해 DigitalOcean DNS API 로 라우팅
+- 각 provider 는 동일한 shape 을 구현합니다 (`setupDomainDNS`, `verifyDomainOwnership`, `checkProvider`). 디스패처는 `src/lib/dns-provider.ts` 에 있습니다.
+- Provider 격리는 integration suite 가 검증합니다 (`DNS_PROVIDER` 모드에 따라 한 provider 의 클라이언트만 호출됨을 보증)
+
+### PostgreSQL
+
+- Raw `pg` 클라이언트, ORM 없음
+- 스키마 변경은 `database.sql` 과 `src/lib/database.ts` 의 TypeScript interface 를 함께 직접 수정
+- Connection string 은 `DATABASE_URL`
+
+## 보안 기능
+
+- JWT 기반 admin 인증 (`NEXTAUTH_SECRET`)
+- API key 해싱 (`bcryptjs`)
+- 입력 검증 (`zod`)
+- 시크릿은 환경 변수에서만 읽음 — `.env.local` 및 동등 파일은 git-ignore 됨, `.env.local.example` 은 placeholder 만 포함
+
+## 배포 옵션
+
+MyResend 는 플랫폼 lock-in 이 없습니다. 지원되는 배포 옵션은 [DEPLOYMENT.ko.md](./DEPLOYMENT.ko.md) 에 정리되어 있습니다:
+
+1. **Docker** (Dockerfile 포함)
+2. **Dokku** (git-push 배포)
+3. **Coolify / CapRover / 기타 PaaS** (container-aware)
+4. **Fly.io**
+5. **Vercel**
+6. **Kubernetes** (`k8s/` 에 샘플 매니페스트 — 후속 sweep 예정 항목)
+
+## 환경 변수
+
+핵심 설정 (전체 키 reference 는 `CLAUDE.md § Environment Configuration`, 템플릿은 `.env.local.example` 참조):
+
+- 데이터베이스: `DATABASE_URL`
+- AWS: `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
+- DNS provider: `DNS_PROVIDER`, `DO_API_TOKEN` (DigitalOcean) 또는 `AWS_HOSTED_ZONE_ID` (Route53, 선택)
+- 보안: `NEXTAUTH_SECRET`
+- Admin 시드: `ADMIN_EMAIL`, `ADMIN_PASSWORD`
+
+## 시작하기
+
+1. **서비스 프로비저닝**: PostgreSQL + AWS SES + (DigitalOcean DNS 또는 Route53)
+2. **환경 설정**: `cp .env.local.example .env.local` 후 값 입력
+3. **데이터베이스 초기화**: `psql "$DATABASE_URL" -f database.sql`
+4. **설치 & 실행**: `npm install && npm run dev`
+5. **Admin 시드**: `curl -X POST http://localhost:3000/api/setup`
+6. **연결 확인**: 로그인 후 Connections 탭 — SES 와 DNS 카드 모두 `ok: true` 여야 합니다
+7. **도메인 추가**: Domains 탭에서 첫 도메인을 추가하고 검증
+8. **API key 생성**: 검증된 도메인에 대해 `mrs_<id>_<secret>` key 발급
+9. **메일 발송**: MyResend base URL 을 가리킨 Resend SDK 로 발송
+
+## Resend 호환성
+
+MyResend 는 Resend 와 동일한 API contract 를 구현합니다:
+
+```javascript
+// baseURL 만 바꾸면 나머지는 그대로 동작합니다
+const resend = new Resend("mrs_your-api-key", {
+  baseURL: "https://your-my-resend.example.com/api",
+});
+```
+
+## 향후 개선
+
+- 이메일 템플릿
+- 캠페인 관리
+- 고급 분석
+- 다중 사용자 지원
+- SMTP relay
+- 메일 발송 스케줄링
+- 향상된 webhook 라우팅
+
+---
+
+upstream 프로젝트로부터의 attribution 과 divergence boundary 는 [NOTICE](./NOTICE) 에 기록되어 있습니다.

--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -1,5 +1,7 @@
 # MyResend - Project Summary
 
+> 🌐 **Languages**: **English** · [한국어](./PROJECT_SUMMARY.ko.md)
+
 ## Overview
 
 MyResend is a self-hosted, Resend-compatible mail gateway. It is built on Next.js 15, delivers email through Amazon SES via the AWS SDK v3 (`@aws-sdk/client-sesv2`), and manages domain DNS records through either DigitalOcean DNS or AWS Route53 — selectable at runtime via the `DNS_PROVIDER` environment variable.

--- a/SETUP.ko.md
+++ b/SETUP.ko.md
@@ -1,0 +1,296 @@
+# MyResend 셋업 가이드
+
+> 🌐 **언어**: [English](./SETUP.md) · **한국어**
+
+이 가이드는 로컬에서 MyResend 를 처음부터 띄우는 절차를 안내합니다. 운영 배포는 [DEPLOYMENT.ko.md](./DEPLOYMENT.ko.md) 를 참고하세요.
+
+## 1. 사전 준비
+
+### PostgreSQL 데이터베이스
+
+MyResend 는 raw `pg` 쿼리를 사용하며 (ORM 없음) 단일 SQL 파일에서 부트스트랩합니다. PostgreSQL 14+ 면 어떤 인스턴스도 호환됩니다.
+
+1. **옵션 A: 로컬 PostgreSQL**
+
+   ```bash
+   # PostgreSQL 설치 (macOS)
+   brew install postgresql
+   brew services start postgresql
+
+   # 데이터베이스 생성 (snake_case — Postgres identifier 는 quoting 없이 쓰려면 snake_case 권장)
+   createdb my_resend
+   ```
+
+2. **옵션 B: Docker**
+
+   ```bash
+   docker run -d --name my-resend-pg \
+     -e POSTGRES_PASSWORD=postgres \
+     -e POSTGRES_DB=my_resend \
+     -p 5432:5432 postgres:15-alpine
+   ```
+
+3. **옵션 C: 관리형 Postgres**
+
+   PostgreSQL 호환 서비스 (AWS RDS, Google Cloud SQL, DigitalOcean Managed Databases, Neon, Render 등) 면 어떤 것이든 가능합니다. 데이터베이스를 프로비저닝 한 뒤 connection string 을 `DATABASE_URL` 에 넣으세요.
+
+4. **스키마 초기화:**
+
+   ```bash
+   # database.sql 이 다음 테이블을 만듭니다:
+   # users, domains, api_keys, email_logs, webhook_events, waitlist_signups
+   psql "$DATABASE_URL" -f database.sql
+   ```
+
+### AWS SES 셋업
+
+1. [AWS SES Console](https://console.aws.amazon.com/ses/) 로 이동합니다.
+2. 임의의 수신자에게 메일을 보낼 준비가 되면 production access (sandbox 해제) 를 요청합니다. Sandbox 모드에서도 도메인 verify 와 admin UI 둘러보기는 가능합니다.
+3. 다음 IAM 정책을 가진 IAM 사용자를 생성합니다. 액션은 MyResend 가 실제로 호출하는 SES v2 명령과 1:1 대응합니다 (참조: `src/lib/ses.ts`, `src/app/api/health/ses/route.ts`):
+
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Sid": "MyResendSesV2",
+         "Effect": "Allow",
+         "Action": [
+           "ses:SendEmail",
+           "ses:GetAccount",
+           "ses:CreateEmailIdentity",
+           "ses:GetEmailIdentity",
+           "ses:PutEmailIdentityDkimAttributes",
+           "ses:DeleteEmailIdentity",
+           "ses:CreateConfigurationSet"
+         ],
+         "Resource": "*"
+       }
+     ]
+   }
+   ```
+
+### DNS Provider (둘 중 하나 선택)
+
+MyResend 는 `DNS_PROVIDER` 환경변수로 선택된 provider 에 도메인 DNS 셋업을 위임합니다. 둘 중 하나를 고르세요:
+
+1. **Route53** (기본값, `DNS_PROVIDER=route53`)
+
+   AWS 계정이 이미 SES 를 운영하고 있다면 권장합니다 — 동일 IAM principal 로 Route53 도 관리할 수 있어 별도 credential 이 필요 없고, 발송 + DNS 전체 흐름이 하나의 audit trail 에 남습니다.
+
+   **a. 발송 도메인용 Route53 hosted zone 생성**
+
+   - AWS Console → Route53 → Hosted zones → **Create hosted zone** 으로 이동합니다.
+   - Domain name: 발송에 사용할 apex 도메인 (예: `example.com`). `mail.example.com` 같은 서브도메인은 별도 subzone 으로 운영해도 되고, apex zone 으로 함께 다뤄도 됩니다 — MyResend 의 `AWS_HOSTED_ZONE_ID` 자동 탐지가 parent zone 까지 walk-up 하기 때문에 보통 apex 만 두면 충분합니다.
+   - Type: **Public hosted zone**.
+   - AWS 가 새 zone 에 할당한 4 개의 NS 레코드를 기록해두세요 — 다음 (b) 단계에서 사용합니다.
+
+   **b. 도메인 등록기관에서 NS 위임**
+
+   도메인 등록기관 (Namecheap, GoDaddy, Cloudflare-as-registrar, Gandi 등) 에서 기존 NS 레코드를 (a) 단계의 4 개 NS 값으로 교체합니다. DNS propagation 은 이전 TTL 에 따라 수 분에서 48 시간까지 걸릴 수 있습니다. 위임이 완료되기 전까지는 MyResend 가 Route53 에 기록한 SES verification TXT 레코드가 public DNS 에 보이지 않아 도메인 verification 이 "pending" 상태로 머무릅니다.
+
+   도메인이 이미 Route53 에 등록되어 있다면 (예: Route53 Domains 로 등록했거나 이전 프로젝트에서 사용 중), (a) 와 (b) 는 건너뜁니다.
+
+   **c. Route53 IAM 정책 첨부**
+
+   위 SES 단계의 IAM 사용자에 다음 statement 를 추가합니다. 액션은 MyResend 가 `src/lib/route53.ts` 에서 호출하는 Route53 명령과 1:1 대응합니다:
+
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Sid": "MyResendRoute53",
+         "Effect": "Allow",
+         "Action": [
+           "route53:ListHostedZones",
+           "route53:ListHostedZonesByName",
+           "route53:GetHostedZone",
+           "route53:ChangeResourceRecordSets",
+           "route53:ListResourceRecordSets",
+           "route53:GetChange"
+         ],
+         "Resource": "*"
+       }
+     ]
+   }
+   ```
+
+   `route53:GetChange` 는 MyResend 자체에서 호출되지 않지만, AWS Console 이나 CLI 로 변경 propagation 상태를 직접 확인하고 싶을 때 정책 재편집 없이 쓸 수 있도록 포함되어 있습니다.
+
+   **d. (선택) `AWS_HOSTED_ZONE_ID` 로 특정 hosted zone 핀**
+
+   - **미설정 (권장)** — single-zone 또는 apex + subdomain 셋업에 적합합니다. MyResend 가 발송 도메인에 대해 `ListHostedZonesByName` 을 호출하고 필요시 parent zone 까지 walk-up 합니다 — 예: `mail.example.com` 을 추가하면 자동으로 `example.com` hosted zone 으로 해석됩니다. 자동 탐지 결과는 프로세스 단위로 메모이즈됩니다.
+   - **명시 설정** (`AWS_HOSTED_ZONE_ID=Z0123456789ABCDEFGHIJ`) — Route53 hosted zone 을 여러 개 운영 중이고 MyResend 를 특정 zone 에만 묶고 싶을 때 사용합니다. 예를 들어 여러 팀이 AWS 계정을 공유하고 그 중 한 팀만 MyResend 가 손댈 zone 을 소유한 경우.
+
+   **e. 검증**
+
+   배포 후 admin **Connections** 탭의 DNS 카드가 `/api/health/dns` → `route53:ListHostedZones` 를 호출합니다. 카드가 초록색이면 IAM 정책 / region / credential 이 모두 정상 연결된 것입니다. 빨간색이면 응답 body 가 실패한 액션을 알려줍니다.
+
+2. **DigitalOcean** (`DNS_PROVIDER=digitalocean`)
+
+   DNS 가 이미 DigitalOcean 에 있고 Route53 으로 마이그레이션 하고 싶지 않을 때 사용합니다. [DigitalOcean → API → Tokens](https://cloud.digitalocean.com/account/api/tokens) 에서 read+write scope 의 API 토큰을 생성하고, 대상 도메인을 DO 의 DNS 관리에 추가한 뒤 `DO_API_TOKEN` 을 설정합니다.
+
+## 2. 환경 변수 설정
+
+1. example 환경 파일을 복사합니다:
+
+   ```bash
+   cp .env.local.example .env.local
+   ```
+
+2. `.env.local` 에 실제 값을 채웁니다. 전체 키 집합과 각 키의 의미는 `CLAUDE.md § Environment Configuration` 에 정리되어 있습니다. 로컬 부팅에 필요한 최소 집합은 다음과 같습니다:
+
+   ```env
+   # 데이터베이스
+   DATABASE_URL=postgresql://postgres:postgres@localhost:5432/my_resend
+
+   # AWS SES (필수)
+   AWS_REGION=us-east-1
+   AWS_ACCESS_KEY_ID=AKIA...
+   AWS_SECRET_ACCESS_KEY=...
+
+   # DNS provider (기본값: route53)
+   DNS_PROVIDER=route53
+   # AWS_HOSTED_ZONE_ID=...       # 선택, 미설정 시 route53 가 자동 탐지
+   # DO_API_TOKEN=dop_v1_...      # DNS_PROVIDER=digitalocean 일 때만 필수
+
+   # 보안
+   NEXTAUTH_SECRET=               # 64자 이상 랜덤 — `openssl rand -base64 64`
+
+   # Admin 사용자 (첫 POST /api/setup 으로 시드됨)
+   ADMIN_EMAIL=admin@example.com
+   ADMIN_PASSWORD=                # 강한 비밀번호
+   ```
+
+## 3. 설치
+
+```bash
+# 의존성 설치 (지원되는 패키지 매니저는 npm 뿐 — package-lock.json 이 커밋됨)
+npm install
+
+# 개발 서버 시작 (Next.js 15, Turbopack)
+npm run dev
+
+# 별도 터미널에서 ADMIN_EMAIL / ADMIN_PASSWORD 로 기본 admin 사용자를 시드합니다
+curl -X POST http://localhost:3000/api/setup
+```
+
+## 4. 첫 단계
+
+1. `http://localhost:3000` 에 접속하고 admin credential 로 로그인합니다.
+2. **Connections** 탭을 엽니다 — SES 카드와 DNS provider 카드 모두 `ok: true` 를 표시해야 합니다. 둘 중 하나라도 실패하면 응답 payload 에 비-시크릿 힌트 (region, IAM 진단 등) 가 포함됩니다.
+3. **Domains** 탭에서 첫 도메인을 추가합니다 — MyResend 가 필요한 SES verification TXT, DKIM CNAME, SPF, DMARC, MX 레코드를 생성하고 활성 DNS provider 에 자동으로 적용합니다.
+4. 도메인 verification 을 기다립니다 (탭 안에서 polling).
+5. **API Keys** 탭에서 API key 를 생성합니다 (key 는 검증된 도메인에 대해서만 발급 가능).
+6. Resend 호환 API 로 메일 발송을 시작합니다.
+
+## 5. API 테스트
+
+`src/lib/__tests__` 와 route 옆 `__tests__` 디렉터리의 Jest 슈트가 동작 검증의 source of truth 입니다 — AWS SDK 와 axios 를 mock 하므로 실제 endpoint 를 호출하지 않습니다.
+
+실행 중인 인스턴스에 대한 ad-hoc end-to-end probing 은 다음과 같이 합니다:
+
+```bash
+# Health check
+curl http://localhost:3000/api/health/ses
+
+# 메일 발송 (API key 로 교체 — 형식 mrs_<id>_<secret>)
+curl -X POST http://localhost:3000/api/emails \
+  -H "Authorization: Bearer mrs_..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "from": "noreply@example.com",
+    "to": ["recipient@example.com"],
+    "subject": "Test Email",
+    "html": "<h1>Hello from MyResend!</h1>"
+  }'
+```
+
+## 6. 운영 배포
+
+MyResend 는 플랫폼 lock-in 없는 표준 Next.js 15 앱입니다. 컨테이너 친화적 옵션 (Docker, Dokku, Coolify, Fly.io, Vercel, Kubernetes, 일반 VPS) 모두 호환됩니다. 옵션별 가이드는 [DEPLOYMENT.ko.md](./DEPLOYMENT.ko.md) 를 참고하세요.
+
+## 7. 도메인 DNS 레코드
+
+admin UI 로 도메인을 추가하면 MyResend 가 아래 레코드들을 자동으로 생성·적용합니다. 수동 검증이나 지원되지 않는 DNS 환경에서 사용할 수 있도록 여기 나열합니다.
+
+### SES 도메인 검증
+
+```
+Type: TXT
+Name: _amazonses.example.com
+Value: [CreateEmailIdentity 가 반환하는 verification 토큰]
+```
+
+### DKIM (CNAME 3 개)
+
+```
+Type: CNAME
+Name: <token>._domainkey.example.com
+Value: <token>.dkim.amazonses.com
+```
+
+### SPF
+
+```
+Type: TXT
+Name: example.com
+Value: v=spf1 include:amazonses.com ~all
+```
+
+### DMARC
+
+```
+Type: TXT
+Name: _dmarc.example.com
+Value: v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com
+```
+
+### MX (SES 로 메일 수신도 하고 싶을 때만)
+
+```
+Type: MX
+Name: example.com
+Value: 10 inbound-smtp.us-east-1.amazonaws.com
+```
+
+## 8. 트러블슈팅
+
+1. **데이터베이스 연결 실패**
+
+   - `DATABASE_URL` 이 정상 파싱되는지 확인 (`psql "$DATABASE_URL" -c '\dt'`) 하고 스키마가 적용됐는지 점검합니다.
+   - `psql "$DATABASE_URL" -f database.sql` 을 재실행 — 스크립트는 idempotent (`CREATE TABLE IF NOT EXISTS`) 이라 안전합니다.
+
+2. **`/api/health/ses` 가 `ok: false` 반환**
+
+   - `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` 를 다시 확인합니다.
+   - 위 IAM 정책이 첨부됐는지 확인합니다. 가장 흔한 원인은 `ses:GetAccount` 누락입니다.
+   - Sandbox 에서는 발송이 제한되지만 `GetAccount` 는 여전히 `ok: true` 를 반환합니다.
+
+3. **`/api/health/dns` 가 `ok: false` 반환**
+
+   - **Route53** (기본값):
+     - § 1 의 IAM 정책이 SES credential 과 동일한 사용자에 첨부되어 있는지 확인합니다. 가장 흔한 원인은 `route53:ListHostedZones` 누락 — health probe 가 처음 호출하는 액션입니다.
+     - hosted zone 을 여러 개 운영 중이고 probe 가 `GetHostedZone` 에서 실패하면 `AWS_HOSTED_ZONE_ID` 를 명시해 zone 을 핀하세요. 그렇지 않으면 미설정으로 두어 자동 탐지가 parent zone 까지 walk-up 하게 합니다.
+     - Region 은 무관합니다 — Route53 은 글로벌입니다. `AWS_REGION` 은 SES 에만 영향을 줍니다.
+     - Cross-account 시나리오 (A 계정에서 발송, B 계정에서 DNS) 는 단일 IAM 사용자로 지원되지 않습니다 — DNS 를 SES 계정으로 옮기거나 두 개의 MyResend 인스턴스를 따로 운영하세요.
+   - **DigitalOcean**: read+write scope 의 `DO_API_TOKEN` 을 재생성합니다. write scope 가 빠진 토큰은 connection check 는 통과해도 `setupDomainDNS` 에서 실패합니다.
+
+4. **도메인 verification 이 "pending" 상태에 머무름**
+
+   - DNS propagation 은 수 분에서 수 시간이 걸릴 수 있습니다. DNS provider 에서 보이는 레코드가 Domains 탭이 생성한 값과 일치하는지 확인합니다.
+   - DKIM 토큰은 재시도 시점에 DNS 레코드로 흘러들어옵니다 — 첫 적용 시점에 SES 가 토큰을 아직 반환하지 않아 빠질 수 있습니다.
+   - **Route53 한정**: AWS Console 에는 레코드가 보이는데 public 인터넷에서 `dig` 결과가 비어있다면 등록기관이 여전히 이전 nameserver 를 가리키는 것입니다. § 1 (b) 단계의 NS 위임을 다시 확인합니다.
+
+5. **API key 인증 실패**
+
+   - key 를 발급하기 전에 도메인이 검증됐는지 확인합니다.
+   - 키 형식: `mrs_<id>_<secret>`.
+
+## 9. 참고
+
+- API 문서: [README.ko.md](./README.ko.md)
+- 데이터베이스 스키마: [database.sql](./database.sql)
+- 환경 변수 reference: `CLAUDE.md § Environment Configuration`
+- 구현 진입점: `src/lib/ses.ts`, `src/lib/dns-provider.ts`, `src/lib/route53.ts`, `src/lib/digitalocean.ts`

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,5 +1,7 @@
 # MyResend Setup Guide
 
+> 🌐 **Languages**: **English** · [한국어](./SETUP.ko.md)
+
 This guide walks you through running MyResend from scratch on a local machine. For production deployment, see [DEPLOYMENT.md](./DEPLOYMENT.md).
 
 ## 1. Prerequisites Setup
@@ -288,7 +290,7 @@ Value: 10 inbound-smtp.us-east-1.amazonaws.com
 
 ## 9. References
 
-- API documentation: [README.md](./README.md) (English) or [README.ko.md](./README.ko.md) (Korean)
+- API documentation: [README.md](./README.md)
 - Database schema: [database.sql](./database.sql)
 - Environment variable reference: `CLAUDE.md § Environment Configuration`
 - Implementation entry points: `src/lib/ses.ts`, `src/lib/dns-provider.ts`, `src/lib/route53.ts`, `src/lib/digitalocean.ts`

--- a/docs/plan/010-4-korean-translation-paired-docs.md
+++ b/docs/plan/010-4-korean-translation-paired-docs.md
@@ -1,0 +1,95 @@
+# 010-4-korean-translation-paired-docs
+
+## 개요
+
+- **이슈**: [#27](https://github.com/Orchemi/my-resend/issues/27)
+- **브랜치**: `feat/27` (stacked on `feat/26` → `feat/25` → `feat/24`)
+- **상태**: 진행 중
+- **생성일**: 2026-05-14
+- **선행**: plan 010-3 (PR #26, feat/26). 본 plan 은 010 sweep 시리즈의 마무리 단계로, Tier 1~3 정렬이 끝난 영문 문서를 한국어로 번역하여 README.ko.md 와 짝을 맞춘다.
+
+## 배경
+
+`README.md` / `README.ko.md` 가 line 3 toggle (`🌐 **Languages**: **English** · [한국어]`) 패턴으로 잘 정착되어 있다. 그러나 README 에서 들어온 한국어 사용자가 `SETUP.md` / `DEPLOYMENT.md` / `PROJECT_SUMMARY.md` 로 이동하는 순간 영문으로 떨어진다 — 일관성 단절.
+
+본 plan 은 3 영문 문서를 한국어로 번역해 `.ko.md` 짝을 만들고, cross-link 를 언어 모드별로 정렬해 사용자가 한 번 한국어 모드에 진입하면 그대로 머무를 수 있게 한다.
+
+## 목표
+
+- [ ] plan 010-4 본 문서 신설
+- [ ] `SETUP.ko.md` 신설 — SETUP.md 한국어 번역, README.ko.md 톤 일치
+- [ ] `DEPLOYMENT.ko.md` 신설 — DEPLOYMENT.md 한국어 번역
+- [ ] `PROJECT_SUMMARY.ko.md` 신설 — PROJECT_SUMMARY.md 한국어 번역
+- [ ] 영문 + 한글 6 파일 line 3 에 언어 toggle 라인 추가
+- [ ] Cross-link 언어별 정렬
+- [ ] CI 4단 통과
+
+## 설계
+
+### 번역 정책
+
+1. **영문이 source of truth**. 영문 변경 시 한글이 parity 를 유지한다 — README.md L419 의 안내와 동일 규칙
+2. **톤**: README.ko.md 패턴을 그대로 답습 — 해요체 / 명사형 혼용, 기술 용어는 영문 그대로 (`hosted zone`, `Bearer token` 등)
+3. **단일 파일 (한글 버전 없음) 참조**:
+   - `NOTICE`, `LICENSE` — 법적 문서. 영문 단일 권위 출처
+   - `CLAUDE.md` — LLM 어시스턴트 컨텍스트. 영문 유지가 OSS 컨벤션
+   - `database.sql`, `.env.local.example` — 코드/설정 파일
+   - 위 단일 파일은 영문/한글 양쪽 모두 동일하게 참조
+4. **한국어 fixture 도메인**: 영문과 동일하게 RFC 2606 (`example.com` / `example.org` / `example.net`) 사용
+5. **OSS 가시성**: 한국어 본문에도 `horbis` / `.claude.local` / `홈서버` / `huns.site` 등 누출 금지
+
+### Toggle 라인 패턴
+
+영문 (line 3):
+```markdown
+> 🌐 **Languages**: **English** · [한국어](./SETUP.ko.md)
+```
+
+한글 (line 3):
+```markdown
+> 🌐 **언어**: [English](./SETUP.md) · **한국어**
+```
+
+3 쌍 모두 동일 패턴 적용.
+
+### Cross-link 정렬 규칙
+
+| 참조 대상 | 영문 문서에서 | 한글 문서에서 |
+|----------|------------|--------------|
+| `README` | `[README.md](./README.md)` | `[README.ko.md](./README.ko.md)` |
+| `SETUP` | `[SETUP.md](./SETUP.md)` | `[SETUP.ko.md](./SETUP.ko.md)` |
+| `DEPLOYMENT` | `[DEPLOYMENT.md](./DEPLOYMENT.md)` | `[DEPLOYMENT.ko.md](./DEPLOYMENT.ko.md)` |
+| `PROJECT_SUMMARY` | `[PROJECT_SUMMARY.md](./PROJECT_SUMMARY.md)` | `[PROJECT_SUMMARY.ko.md](./PROJECT_SUMMARY.ko.md)` |
+| `NOTICE` | `[NOTICE](./NOTICE)` | `[NOTICE](./NOTICE)` (동일) |
+| `LICENSE` | `[LICENSE](./LICENSE)` | `[LICENSE](./LICENSE)` (동일) |
+| `CLAUDE.md` | `CLAUDE.md` | `CLAUDE.md` (동일) |
+| `CONTRIBUTING.md` | `[CONTRIBUTING.md](./CONTRIBUTING.md)` | `[CONTRIBUTING.md](./CONTRIBUTING.md)` (동일 — 한글본 미존재) |
+| `database.sql`, `.env.local.example` | 그대로 | 그대로 (동일) |
+
+## 010-4 작업 절차 (5 분할 커밋)
+
+| # | 커밋 메시지 | 변경 파일 |
+|---|--------------|-----------|
+| 1 | `docs(plan): add 010-4 korean translation paired docs plan` | `docs/plan/010-4-korean-translation-paired-docs.md` |
+| 2 | `docs(setup): add Korean translation SETUP.ko.md` | `SETUP.ko.md` (신규) + `SETUP.md` toggle + cross-link 정렬 |
+| 3 | `docs(deployment): add Korean translation DEPLOYMENT.ko.md` | `DEPLOYMENT.ko.md` (신규) + `DEPLOYMENT.md` toggle + cross-link 정렬 |
+| 4 | `docs(project-summary): add Korean translation PROJECT_SUMMARY.ko.md` | `PROJECT_SUMMARY.ko.md` (신규) + `PROJECT_SUMMARY.md` toggle + cross-link 정렬 |
+| 5 | `docs(repo): pair Korean docs in CONTRIBUTING and add cross-link parity check` | `CONTRIBUTING.md` (한글 문서 가리키는 라인 정리, 영문본은 영문만 가리킴) |
+
+## 머지 기준
+
+- [ ] CI 4단 통과
+- [ ] 3 영문 + 3 한글 = 6 파일 line 3 에 toggle 라인 존재 (`grep -nE "^> 🌐 \\*\\*(Languages|언어)\\*\\*" {SETUP,DEPLOYMENT,PROJECT_SUMMARY}{,.ko}.md` 결과 6 hits)
+- [ ] 영문 문서 안에서 `*.ko.md` 참조 = toggle 라인 1 곳만 (cross-link 본문 내 0)
+- [ ] 한글 문서 안에서 비-`*.ko.md`·비-단일파일 참조 0 (단일파일·toggle 제외)
+
+## 비스코프
+
+- `CLAUDE.md`, `NOTICE`, `LICENSE`, `CONTRIBUTING.md` 한국어 번역 — 사유는 § 설계 § 단일 파일 참조 단락
+- `.kiro/specs/hosted-version-waitlist/` (Tier 4 marketing) — plan 010 의 결정대로 보류
+
+## 진행 로그
+
+| 날짜 | 내용 |
+|------|------|
+| 2026-05-14 | 이슈 #27, `feat/27` 분기, 본 plan 작성 |


### PR DESCRIPTION
## Summary

- `SETUP.md` / `DEPLOYMENT.md` / `PROJECT_SUMMARY.md` 의 한국어 번역 3 쌍 신설
- 6 파일 모두 line 3 에 언어 toggle 추가 (`🌐 **Languages** / **언어**` 패턴, README 쌍과 동일)
- Cross-link 언어별 정렬 (영문 → 영문, 한글 → 한글, 단일 파일은 양쪽 동일)
- plan 010-4 인덱싱

Closes #27

## Details

PR #28~#32 (Tier 1~3 + DNS alignment) 후속. README 쌍이 line 3 toggle 패턴으로 잘 정착되어 있으나, 한국어 사용자가 README.ko.md 에서 SETUP/DEPLOYMENT/PROJECT_SUMMARY 로 이동하는 순간 영문으로 떨어지는 단절이 있었다.

**번역 정책 (plan 010-4 § 설계)**
- 영문이 source of truth — 영문 변경 시 한글이 parity 유지 (README.md L419 의 기존 안내와 동일)
- 톤: README.ko.md 와 동일한 해요체 + 명사형, 기술 용어는 영문 그대로 (hosted zone, Bearer token 등)
- RFC 2606 fixture 도메인 사용
- 한글 본문에도 horbis / .claude.local / 홈서버 등 OSS 가시성 위반 0

**Cross-link 언어별 정렬**
- 영문 문서 → 영문 cross-reference + line 3 toggle 의 한글 1 줄
- 한글 문서 → 한글 cross-reference + line 3 toggle 의 영문 1 줄
- 단일 파일 (NOTICE, LICENSE, CLAUDE.md, database.sql, .env.local.example) 은 양쪽 동일 참조

**비스코프** (한글 번역 안 함):
- `CLAUDE.md` — LLM 어시스턴트 컨텍스트 (영문 유지가 OSS 컨벤션)
- `NOTICE`, `LICENSE` — 법적 문서 (영문 단일 권위 출처)
- `CONTRIBUTING.md` — contributor 가 영어 사용자 일반적

## Changes

```
docs/plan/
└── 010-4-korean-translation-paired-docs.md     # 신규
SETUP.ko.md                                      # 신규 — 한국어 번역
DEPLOYMENT.ko.md                                 # 신규 — 한국어 번역
PROJECT_SUMMARY.ko.md                            # 신규 — 한국어 번역
SETUP.md                                         # line 3 toggle 추가
DEPLOYMENT.md                                    # line 3 toggle 추가
PROJECT_SUMMARY.md                               # line 3 toggle 추가
```

## Commits

- [`d6c9141`](https://github.com/Orchemi/my-resend/commit/d6c9141) docs(plan): add 010-4 korean translation paired docs plan
- [`26155b8`](https://github.com/Orchemi/my-resend/commit/26155b8) docs(setup): add Korean translation SETUP.ko.md
- [`9a7c2b4`](https://github.com/Orchemi/my-resend/commit/9a7c2b4) docs(deployment): add Korean translation DEPLOYMENT.ko.md
- [`b3c470f`](https://github.com/Orchemi/my-resend/commit/b3c470f) docs(project-summary): add Korean translation PROJECT_SUMMARY.ko.md

## Test plan

- [x] CI 4단 (lint / typecheck / test 162 / build) 통과
- [x] 8 파일 line 3 toggle 라인 존재 (영문 4 + 한글 4)
- [x] 영문 문서 내 한글 `*.ko.md` 참조 = toggle 1 줄만 (본문 0)
- [x] 한글 문서 내 영문 `*.md` 참조 = toggle 1 줄만 (단일 파일 제외)
- [x] OSS 가시성 위반 0 hits
- [x] 한글 본문 내 RFC 2606 fixture 도메인 사용