### PR TITLE
Replace upstream-author personal links in LandingPage footer

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -532,10 +532,10 @@ export default function LandingPage() {
                 </li>
                 <li>
                   <a
-                    href="https://x.com/eibrahim"
+                    href="https://www.linkedin.com/in/huns"
                     className="text-gray-400 hover:text-white transition-colors"
                   >
-                    Twitter
+                    LinkedIn
                   </a>
                 </li>
               </ul>
@@ -554,7 +554,7 @@ export default function LandingPage() {
                 </li>
                 <li>
                   <a
-                    href="https://x.com/eibrahim"
+                    href="mailto:tmdgns1126@naver.com"
                     className="text-gray-400 hover:text-white transition-colors"
                   >
                     Contact
@@ -568,10 +568,10 @@ export default function LandingPage() {
             <p className="text-gray-400">
               Built by{" "}
               <a
-                href="https://x.com/eibrahim"
+                href="https://github.com/Orchemi"
                 className="text-blue-400 hover:text-blue-300"
               >
-                @eibrahim
+                Park Seunghun
               </a>{" "}
               • MIT Licensed • Made with ❤️ for developers.
             </p>


### PR DESCRIPTION
Closes #36.

## Summary
- Rewrite the three eibrahim-linked items in the LandingPage footer to match the current maintainer.
- Keep all hard-fork attribution lines (NOTICE / LICENSE / README L7 / CLAUDE.md L9) untouched.

## Why

`src/components/LandingPage.tsx` (lines 535, 557, 571-574) still carried links to the upstream project author rather than the current maintainer — "Twitter", "Contact", and "Built by @eibrahim" all pointed at `x.com/eibrahim`. Dashboard's footer at `src/components/Dashboard.tsx:100-111` already follows the right pattern ("Built by Park Seunghun" → `github.com/Orchemi`, with a separate NOTICE pointer for fork attribution). The landing page was missed during the earlier brand sweep.

## Changes

| Where | Before | After |
|-------|--------|-------|
| Community menu | `Twitter` → `x.com/eibrahim` | `LinkedIn` → `linkedin.com/in/huns` |
| Legal menu | `Contact` → `x.com/eibrahim` | `Contact` → `mailto:tmdgns1126@naver.com` |
| Footer bottom | `Built by @eibrahim` → `x.com/eibrahim` | `Built by Park Seunghun` → `github.com/Orchemi` |

```
src/
└── components/
    └── LandingPage.tsx                              # footer: Community/Legal/Built-by links
```

## Commits
- [`4b47f83`](https://github.com/Orchemi/my-resend/commit/4b47f83) fix(branding): replace upstream-author personal links in LandingPage footer

## Verification

```
npm run lint        ✓ no warnings
npm run typecheck   ✓ 0 errors
npm test --runInBand --testPathIgnorePatterns='WaitlistSignup'
                    ✓ 174 / 174 (16 suites)
npm run build       ✓
```

`git grep eibrahim -- src/` returns 0 after this PR — every remaining hit lives in intended-attribution surfaces (NOTICE, LICENSE, README § 1, CLAUDE.md § 1) or in historical plan documents.

## Out of scope

- Other LandingPage copy (hero / pricing / features) — not author attribution.
- Dashboard footer — already correct.
- Documentation files with the intended fork attribution.