### PR TITLE
Make pricing calculator inputs readable

### DIFF
--- a/src/components/PricingCalculator.tsx
+++ b/src/components/PricingCalculator.tsx
@@ -184,7 +184,7 @@ export default function PricingCalculator({
                   type="number"
                   value={volume}
                   onChange={(e) => handleVolumeChange(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                   min="0"
                   max="5000000"
                   step="1000"
@@ -268,7 +268,7 @@ export default function PricingCalculator({
                       type="number"
                       value={flatFee.toFixed(2)}
                       onChange={(e) => handleFlatFeeChange(e.target.value)}
-                      className="w-full pl-8 pr-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      className="w-full pl-8 pr-3 py-2 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                       min="0"
                       step="0.50"
                       aria-label="Optional platform fee in USD"
@@ -292,7 +292,7 @@ export default function PricingCalculator({
                       type="number"
                       value={sesRate.toFixed(2)}
                       onChange={(e) => handleSesRateChange(e.target.value)}
-                      className="w-full pl-8 pr-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      className="w-full pl-8 pr-3 py-2 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                       min="0"
                       step="0.01"
                       aria-label="SES rate per 1000 emails in USD"
@@ -313,7 +313,7 @@ export default function PricingCalculator({
                       type="number"
                       value={hostingCost.toFixed(2)}
                       onChange={(e) => handleHostingCostChange(e.target.value)}
-                      className="w-full pl-8 pr-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      className="w-full pl-8 pr-3 py-2 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                       min="0"
                       step="1.00"
                       aria-label="Monthly hosting cost in USD"
@@ -334,7 +334,7 @@ export default function PricingCalculator({
                       type="number"
                       value={maintenanceCost.toFixed(2)}
                       onChange={(e) => handleMaintenanceCostChange(e.target.value)}
-                      className="w-full pl-8 pr-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                      className="w-full pl-8 pr-3 py-2 border border-gray-300 rounded-md text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                       min="0"
                       step="1.00"
                       aria-label="Monthly maintenance cost in USD"


### PR DESCRIPTION
Closes #39.

## Summary
- Add `text-gray-900 placeholder-gray-400` to every input inside `PricingCalculator` so typed values render dark against the light gradient background.

## Why

Inputs in `/pricing` (Monthly Email Volume + the four MyResend Pricing Parameters) only set border / focus styling, with no explicit `text-...` color. The browser default produced a near-invisible value text — the placeholder was readable but the actual typed number wasn't.

## Changes

```
src/
└── components/
    └── PricingCalculator.tsx                     # 5 inputs: + text-gray-900 placeholder-gray-400
```

## Commits
- [`51a7232`](https://github.com/Orchemi/my-resend/commit/51a7232) fix(pricing): set explicit text color on calculator inputs

## Verification

```
npm run lint        ✓ no warnings
npm run typecheck   ✓ 0 errors
npm test --runInBand
                    ✓ 131 / 131
npm run build       ✓
```

Visually confirmed after rebase onto `develop` (post-PR #41): all five inputs render typed values in `text-gray-900` and placeholders in `text-gray-400`.

## Out of scope

- Dark-mode / color-scheme handling — the pricing page is light-gradient by design; a true dark-mode pass is a separate concern.
- Other input surfaces beyond the pricing calculator.