### PR TITLE
Dedupe header, hero, and footer CTAs

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -53,12 +53,6 @@ export default function LandingPage() {
               </a>
               <Link
                 href="/login"
-                className="text-gray-600 hover:text-gray-900 transition-colors px-3 py-2"
-              >
-                Login
-              </Link>
-              <Link
-                href="/login"
                 className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors flex items-center space-x-2"
               >
                 <span>Get Started</span>
@@ -92,7 +86,7 @@ export default function LandingPage() {
             email infrastructure
           </p>
 
-          <div className="flex flex-col sm:flex-row gap-4 justify-center mb-8">
+          <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
             <Link
               href="/login"
               className="bg-blue-600 text-white px-8 py-4 rounded-lg hover:bg-blue-700 transition-colors flex items-center justify-center space-x-2 font-semibold"
@@ -107,24 +101,6 @@ export default function LandingPage() {
               <DollarSign className="h-5 w-5" />
               <span>See Pricing</span>
             </Link>
-            <a
-              href="https://github.com/Orchemi/my-resend"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="border-2 border-gray-200 text-gray-700 px-8 py-4 rounded-lg hover:border-gray-300 transition-colors flex items-center justify-center space-x-2 font-semibold"
-            >
-              <Github className="h-5 w-5" />
-              <span>View on GitHub</span>
-            </a>
-          </div>
-          
-          <div className="text-center mb-8">
-            <p className="text-sm text-gray-500">
-              Already have an account?{" "}
-              <Link href="/login" className="text-blue-600 hover:text-blue-700 font-medium">
-                Login here
-              </Link>
-            </p>
           </div>
 
           {/* Migration Code Example */}
@@ -444,14 +420,6 @@ export default function LandingPage() {
                     href="https://github.com/Orchemi/my-resend"
                     className="text-gray-400 hover:text-white transition-colors"
                   >
-                    Documentation
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="https://github.com/Orchemi/my-resend"
-                    className="text-gray-400 hover:text-white transition-colors"
-                  >
                     GitHub
                   </a>
                 </li>
@@ -475,14 +443,6 @@ export default function LandingPage() {
                     className="text-gray-400 hover:text-white transition-colors"
                   >
                     Discussions
-                  </a>
-                </li>
-                <li>
-                  <a
-                    href="https://github.com/Orchemi/my-resend/blob/main/CONTRIBUTING.md"
-                    className="text-gray-400 hover:text-white transition-colors"
-                  >
-                    Contributing
                   </a>
                 </li>
                 <li>

--- a/src/components/__tests__/LandingPage.test.tsx
+++ b/src/components/__tests__/LandingPage.test.tsx
@@ -57,27 +57,26 @@ describe('LandingPage', () => {
   it('has correct CTA flow directing new operators to login', () => {
     render(<LandingPage />);
 
-    // Primary CTAs ("Get Started") send the user to /login: one in the
-    // header and two on the page (hero + bottom call-to-action).
+    // After the CTA dedupe the page surfaces one primary CTA in the
+    // header and one in the hero — both Get Started buttons route to
+    // /login. There is no longer a standalone "Login" text link, no
+    // "Login here" affordance, and no hero "View on GitHub" duplicate.
     const getStartedLinks = screen.getAllByRole('link', { name: /get started/i });
     expect(getStartedLinks.length).toBeGreaterThanOrEqual(2);
     getStartedLinks.forEach((link) => {
       expect(link).toHaveAttribute('href', '/login');
     });
 
-    // "See Pricing" still goes to the pricing calculator (OSS cost
-    // comparison tool, not a waitlist funnel).
     expect(screen.getByRole('link', { name: /see pricing/i })).toHaveAttribute('href', '/pricing');
 
-    // No leftover waitlist-era CTAs.
+    expect(screen.queryByRole('link', { name: /^login$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /login here/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /view on github/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /join waitlist/i })).not.toBeInTheDocument();
     expect(screen.queryByText(/hosted version coming soon/i)).not.toBeInTheDocument();
 
-    // Secondary surfaces still wired.
-    expect(screen.getAllByRole('link', { name: /login/i }).length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText(/alternative to resend/i)).toBeInTheDocument();
     expect(screen.getByText(/100% api compatible/i)).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /view on github/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /view documentation/i })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #40.

## Summary
- Drop the duplicate routes to `/login` in the header and hero.
- Drop the hero "View on GitHub" button (GitHub link still lives in the header).
- Trim the footer columns: Resources keeps GitHub + Issues (Documentation was the same repo URL), Community keeps Discussions + LinkedIn (Contributing was another GitHub link).

## Why

After the waitlist/Hosted sweeps (PR #41), the landing page kept multiple links pointing at the same destination. Three concrete duplications were left:

| Surface | Duplicates |
|---------|-----------|
| Header | "Login" text link + "Get Started" CTA — both `/login` |
| Hero | "Get Started" + "See Pricing" + "View on GitHub" + "Already have an account? Login here" — three of the four overlap with the header GitHub link and the Get Started CTA |
| Footer | Resources/Community columns held five separate links to `github.com/Orchemi/my-resend` and its subpaths |

The PR keeps one clear primary CTA per surface.

## Details

### Header
- Drop the standalone `<Link href="/login">Login</Link>` text link.
- Keep "GitHub" (icon link) + "Get Started" CTA.

### Hero
- Drop the third `<a href=".../my-resend">View on GitHub</a>` button.
- Drop the `<p>Already have an account? Login here</p>` line below the CTA row.
- Hero now shows two CTAs: "Get Started" (`/login`, primary) + "See Pricing" (`/pricing`, secondary).

### Footer
- Resources: remove "Documentation" (pointed at repo root). Keeps **GitHub** + **Issues**.
- Community: remove "Contributing" (linked to GitHub `blob/main/CONTRIBUTING.md`). Keeps **Discussions** + **LinkedIn**.
- Legal: unchanged (**MIT License** + **Contact**).

The footer's six github.com links collapse to three: repo root, Issues, Discussions — each with distinct intent.

## Changes

```
src/
└── components/
    ├── LandingPage.tsx                           # header / hero / footer dedupe
    └── __tests__/
        └── LandingPage.test.tsx                  # assert dedupe + Get Started routing
```

## Commits
- [`e4e97a7`](https://github.com/Orchemi/my-resend/commit/e4e97a7) refactor(landing): dedupe header, hero, and footer CTAs

## Verification

```
npm run lint        ✓ no warnings
npm run typecheck   ✓ 0 errors
npm test --runInBand
                    ✓ 131 / 131 (13 suites)
npm run build       ✓
```

Rebased onto `develop` (post-#41 #42) so this PR carries only the dedupe diff.

## Out of scope

- Bottom CTA section (Get Started + View Documentation) — already lean.
- Pricing page CTA cleanup — separate surface.
- Hero copy / feature grid / comparison table — visual hierarchy unchanged.