### PR TITLE
Repoint LICENSE / NOTICE footer links to the develop branch

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -108,7 +108,7 @@ export default function Dashboard() {
               </a>
               <span className="mx-2">•</span>
               <a
-                href="https://github.com/Orchemi/my-resend/blob/main/NOTICE"
+                href="https://github.com/Orchemi/my-resend/blob/develop/NOTICE"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-gray-500 hover:text-gray-700"

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -461,7 +461,7 @@ export default function LandingPage() {
               <ul className="space-y-2">
                 <li>
                   <a
-                    href="https://github.com/Orchemi/my-resend/blob/main/LICENSE"
+                    href="https://github.com/Orchemi/my-resend/blob/develop/LICENSE"
                     className="text-gray-400 hover:text-white transition-colors"
                   >
                     MIT License


### PR DESCRIPTION
Closes #44.

## Summary
- Replace \`blob/main/LICENSE\` and \`blob/main/NOTICE\` (both 404) with \`blob/develop/...\` — the repo default branch.

## Why

The repo has only two branches (\`develop\` default, \`production\` stable); there is no \`main\`. The landing-page footer ("MIT License") and Dashboard footer ("Hard-fork — see NOTICE for upstream attribution") both linked to the missing branch and returned 404 on GitHub.

## Changes

\`\`\`
src/
└── components/
    ├── LandingPage.tsx                          # MIT License link → blob/develop/LICENSE
    └── Dashboard.tsx                            # NOTICE link → blob/develop/NOTICE
\`\`\`

## Commits
- [\`023387c\`](https://github.com/Orchemi/my-resend/commit/023387c) fix(docs): repoint MIT License / NOTICE links to the develop branch

## Verification

\`\`\`
npm run lint        ✓
npm run typecheck   ✓
npm test            ✓ 131 / 131
npm run build       ✓
\`\`\`

## Out of scope

- Renaming the default branch to \`main\`.
- README / CONTRIBUTING content — those use repo-root URLs and relative paths.