### PR TITLE
Clarify the login page is admin-only, with a SETUP.md pointer

### DIFF
--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -34,7 +34,13 @@ export default function LoginForm() {
             Sign in to MyResend
           </h2>
           <p className="mt-2 text-center text-sm text-gray-600">
-            Your self-hosted email service
+            Admin sign-in for your self-hosted MyResend instance.
+          </p>
+          <p className="mt-1 text-center text-xs text-gray-500">
+            This is a single-admin app — credentials are seeded from{" "}
+            <code className="text-xs">ADMIN_EMAIL</code> /{" "}
+            <code className="text-xs">ADMIN_PASSWORD</code> via{" "}
+            <code className="text-xs">POST /api/setup</code>. No public signup.
           </p>
         </div>
         <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
@@ -87,6 +93,19 @@ export default function LoginForm() {
             </button>
           </div>
         </form>
+
+        <p className="text-center text-xs text-gray-500">
+          Haven&apos;t seeded the admin yet? See{" "}
+          <a
+            href="https://github.com/Orchemi/my-resend/blob/develop/SETUP.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 hover:text-blue-700 underline"
+          >
+            SETUP.md § 2–3
+          </a>{" "}
+          for env vars and the seed step.
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #46.

## Summary
- Reword the login page subtitle so first-time visitors understand the page is admin-only.
- Add a one-liner noting credentials come from \`ADMIN_EMAIL\` / \`ADMIN_PASSWORD\` via \`POST /api/setup\` — no public signup.
- Below the form, link to \`SETUP.md § 2–3\` for operators who haven't seeded credentials yet.

## Why

Visiting \`/login\` after the marketing page hits a wall: just "Email address" / "Password" inputs and a "Sign in" button under the subtitle "Your self-hosted email service". Nothing tells the user that:

- This is the admin login for the operator who installed the instance.
- There is no signup link because credentials are seeded from env vars + the setup endpoint.
- The recovery path is editing \`.env.local\` and re-running setup.

## Changes

\`\`\`
src/
└── components/
    └── LoginForm.tsx                            # subtitle + admin clarification + SETUP.md help link
\`\`\`

## Commits
- [\`a834454\`](https://github.com/Orchemi/my-resend/commit/a834454) feat(login): clarify single-admin sign-in with a SETUP.md pointer

## Verification

\`\`\`
npm run lint        ✓
npm run typecheck   ✓
npm test            ✓ 131 / 131
npm run build       ✓
\`\`\`

## Out of scope

- Adding a real signup flow — single-admin app by design.
- Password reset / forgot password — recovery today is "edit \`.env.local\` + re-run setup".
- Visual / styling refactor of the form.