### PR TITLE
Split "Infrastructure: $25" into Hosting + Maintenance in the breakdown

### DIFF
--- a/src/components/PricingCalculator.tsx
+++ b/src/components/PricingCalculator.tsx
@@ -438,7 +438,8 @@ export default function PricingCalculator({
             <div>Includes hosting & maintenance</div>
             <div className="text-xs mt-1 space-y-0.5">
               <div>• SES: {formatUSD(comparison.myResendBreakdown.sesCost)}</div>
-              <div>• Infrastructure: {formatUSD(comparison.myResendBreakdown.hostingCost + comparison.myResendBreakdown.maintenanceCost)}</div>
+              <div>• Hosting: {formatUSD(comparison.myResendBreakdown.hostingCost)}</div>
+              <div>• Maintenance: {formatUSD(comparison.myResendBreakdown.maintenanceCost)}</div>
               {comparison.myResendBreakdown.flatFee > 0 && (
                 <div>• Platform: {formatUSD(comparison.myResendBreakdown.flatFee)}</div>
               )}


### PR DESCRIPTION
Closes #48.

## Summary
- Replace the single \`Infrastructure: \$X\` line in the Self-Hosted card with two lines — \`Hosting: \$X\` + \`Maintenance: \$Y\` — so each breakdown row maps 1:1 to its input field.

## Why

The card showed:

\`\`\`
• SES: \$0.50
• Infrastructure: \$25.00
\`\`\`

But the inputs panel above carries two separate fields, **Hosting Cost** (\$15 default) and **Maintenance Cost** (\$10 default). The summed line made \$25 look like a hardcoded magic number — and adjusting just one of the inputs didn't visibly land on a single output row.

(The Reality Check section further down already presented Hosting and Maintenance on separate rows. This brings the card breakdown in line with it.)

## Changes

\`\`\`
src/
└── components/
    └── PricingCalculator.tsx                    # Infrastructure → Hosting + Maintenance (2 rows)
\`\`\`

## Commits
- [\`de32047\`](https://github.com/Orchemi/my-resend/commit/de32047) refactor(pricing): split Infrastructure line into Hosting + Maintenance

## Verification

\`\`\`
npm run lint        ✓
npm run typecheck   ✓
npm test            ✓ 131 / 131
npm run build       ✓
\`\`\`

## Out of scope

- Merging Hosting + Maintenance into a single input — they're conceptually different (compute / fly.io / VPS fee vs operator time-cost).
- Renaming the input labels.
- Adjusting default values.