### PR TITLE
Split admin UI out to /admin, keep / as the public landing

### DIFF
--- a/SETUP.ko.md
+++ b/SETUP.ko.md
@@ -191,7 +191,7 @@ curl -fsSL -X POST http://localhost:3000/api/setup
 
 ## 4. 첫 단계
 
-1. `http://localhost:3000` 에 접속하고 admin credential 로 로그인합니다.
+1. `http://localhost:3000/admin` 에 접속하고 admin credential 로 로그인합니다.
 2. **Connections** 탭을 엽니다 — SES 카드와 DNS provider 카드 모두 `ok: true` 를 표시해야 합니다. 둘 중 하나라도 실패하면 응답 payload 에 비-시크릿 힌트 (region, IAM 진단 등) 가 포함됩니다.
 3. **Domains** 탭에서 첫 도메인을 추가합니다 — MyResend 가 필요한 SES verification TXT, DKIM CNAME, SPF, DMARC, MX 레코드를 생성하고 활성 DNS provider 에 자동으로 적용합니다.
 4. 도메인 verification 을 기다립니다 (탭 안에서 polling).

--- a/SETUP.md
+++ b/SETUP.md
@@ -191,7 +191,7 @@ The response body now carries a structured `status` field:
 
 ## 4. First Steps
 
-1. Visit `http://localhost:3000` and log in with your admin credentials.
+1. Visit `http://localhost:3000/admin` and log in with your admin credentials.
 2. Open the **Connections** tab — both the SES card and the DNS provider card should report `ok: true`. If either fails, the response payload includes a non-secret hint (e.g. region, IAM diagnostic).
 3. Add your first domain in the **Domains** tab — MyResend generates the required SES verification TXT, DKIM CNAMEs, SPF, DMARC, and MX records and applies them to the active DNS provider automatically.
 4. Wait for domain verification (polled in-tab).

--- a/docs/plan/013-admin-route-split.md
+++ b/docs/plan/013-admin-route-split.md
@@ -1,0 +1,131 @@
+# 013-admin-route-split
+
+## 개요
+
+- **이슈**: [#50](https://github.com/Orchemi/my-resend/issues/50)
+- **브랜치**: `feat/50`
+- **상태**: 진행 중
+- **생성일**: 2026-05-17
+
+마케팅 surface 와 admin UI 가 `/` 라우트 한 곳에서 인증 상태로 분기되던 구조를 분리한다. `/` 는 항상 public landing, admin 은 `/admin` (+ `/admin/login`) 별도 라우트.
+
+## 배경
+
+`src/app/page.tsx` 가 다음 패턴이었다:
+
+```tsx
+if (user)   return <Dashboard />;
+            return <LandingPage />;
+```
+
+upstream `freeresend` 가 "한 앱이 둘 다" — 호스팅 SaaS 마케팅 깔때기 + 어드민 — 을 의도한 설계. 본 fork 는 waitlist / Hosted tier 제거 후 SaaS 가 아니지만 구조적 결합이 남아 있었다. self-host OSS 운영자 입장에서 *자기 인프라가 자기 자신에게 영업하는* 어색한 동선이 된다.
+
+사용자 결정 (옵션 B): 마케팅 surface 는 보존, admin 만 분리.
+
+## 목표
+
+- [ ] plan 문서 작성
+- [ ] `/admin` 라우트 신설 — auth-gate + Dashboard 렌더
+- [ ] `/admin/login` 라우트 신설 — 현재 `/login` 의 LoginForm 재사용
+- [ ] `/` 단순화 — auth 분기 제거, 항상 LandingPage
+- [ ] LandingPage CTAs `/login` → `/admin` 3 hit 갱신
+- [ ] 기존 `/login` 라우트 → `/admin/login` permanent redirect (compat)
+- [ ] LoginPageClient `router.push("/")` → `router.push("/admin")`
+- [ ] 테스트 갱신 — LandingPage CTAs 단언
+- [ ] CI 4단 통과
+- [ ] SETUP.md / SETUP.ko.md 의 `/login` 언급 점검
+
+## 설계
+
+### 라우트 표 (전/후)
+
+| 경로 | 전 | 후 |
+|------|----|----|
+| `/` | 미인증 → LandingPage / 인증 → Dashboard | 항상 LandingPage (공개) |
+| `/login` | LoginForm | `/admin/login` 으로 308 permanent redirect (compat) |
+| `/pricing` | PricingCalculator (공개) | 변경 없음 |
+| `/admin` | (없음, 404) | auth-gate. 미인증 → `/admin/login` redirect. 인증 → Dashboard |
+| `/admin/login` | (없음) | LoginForm. 인증 상태로 진입 시 `/admin` redirect |
+
+### 인증 흐름
+
+- 인증되지 않은 사용자가 `/admin` 진입 → 클라이언트에서 `router.push('/admin/login')`
+- `/admin/login` 진입 후 로그인 성공 → `LoginPageClient` 의 useEffect 가 `user` 갱신 감지 → `router.push('/admin')`
+- 로그아웃 → `useAuth().logout()` 호출 → 컨텍스트 user=null → `/admin` 에서 자동으로 `/admin/login` 으로 이동. (별도 redirect 코드 불필요)
+
+### 컴포넌트 재사용
+
+- `Dashboard.tsx`, `LandingPage.tsx`, `LoginForm.tsx`, `LoginPageClient.tsx` 본체는 변경 없음.
+- `LoginPageClient` 의 redirect target 만 `/` → `/admin` 으로 1줄 수정.
+
+### 변경 범위
+
+```
+src/app/
+├── page.tsx                              # 단순화: 항상 <LandingPage />
+├── login/
+│   └── page.tsx                          # /admin/login 으로 redirect 만 남김
+└── admin/                                # NEW
+    ├── page.tsx                          # NEW — auth gate + <Dashboard />
+    └── login/
+        └── page.tsx                      # NEW — <LoginPageClient />
+
+src/components/
+└── LoginPageClient.tsx                   # router.push("/") → "/admin"
+
+src/components/
+└── LandingPage.tsx                       # /login → /admin (3 hit)
+
+src/components/__tests__/
+└── LandingPage.test.tsx                  # CTAs 단언 갱신
+```
+
+### 의사결정 기록
+
+| 결정 | 선택지 | 결정 | 이유 |
+|------|--------|------|------|
+| 라우트 구조 | (A) `/` admin-only, landing 제거 / (B) `/admin` 분리 / (C) env 플래그 | **B** | 사용자 결정. calculator + 마케팅 surface 보존 가치 인정, admin 만 분리 |
+| 로그인 후 destination | `/` / `/admin` | `/admin` | admin 작업하러 들어왔으니 admin 으로 |
+| 로그아웃 후 destination | `/` / `/admin/login` | 자동 — `/admin` 에서 컨텍스트 변화 감지로 `/admin/login` 이동 | 별도 redirect 코드 없이도 동작. 단순 |
+| CTAs 타겟 | `/admin/login` / `/admin` | **`/admin`** | semantically "go to admin" — 이미 로그인됐으면 바로 dashboard, 아니면 login 으로 우회 |
+| `/login` 처리 | 삭제 / redirect | redirect | 기존 북마크 보존, 비용 거의 없음 (`redirect()` 한 줄) |
+| middleware 추가 | server-side guard / client-only | client-only | single-admin OSS 에서 server middleware 는 over-engineering. 기존 useAuth 패턴 유지 |
+
+## 작업 단계
+
+### Phase 1 — 신규 라우트 추가
+
+- [ ] `src/app/admin/page.tsx` 신설 — 기존 `/` 의 auth 분기 로직을 그대로 가져옴 (loading / unauthenticated redirect / authenticated → Dashboard)
+- [ ] `src/app/admin/login/page.tsx` 신설 — `<LoginPageClient />` 호출
+- [ ] `LoginPageClient` 의 `router.push("/")` → `"/admin"`
+
+### Phase 2 — `/` 단순화 + CTAs
+
+- [ ] `src/app/page.tsx` 단순화 — `<LandingPage />` 단독 렌더
+- [ ] `LandingPage.tsx` 3 hit (`href="/login"`) → `"/admin"`
+
+### Phase 3 — 호환 redirect
+
+- [ ] `src/app/login/page.tsx` 본문 → `redirect("/admin/login")` (Next.js 의 `next/navigation` redirect)
+
+### Phase 4 — 테스트 + 문서
+
+- [ ] `LandingPage.test.tsx` — Get Started CTAs href 단언 `/login` → `/admin`
+- [ ] `SETUP.md` / `SETUP.ko.md` 의 로그인 언급 점검 (있으면 `/admin` 으로 안내)
+- [ ] CI 4단 통과 확인
+
+### Phase 5 — Merge
+
+- [ ] commit 분할 (plan / 신규 라우트+admin gate / `/` 단순화+CTAs / `/login` redirect+docs)
+- [ ] PR → develop, merge commit
+
+## 진행 로그
+
+| 날짜 | 내용 | 비고 |
+|------|------|------|
+| 2026-05-17 | 이슈 #50 + feat/50 + plan 작성 | |
+
+## 참고
+
+- 선행: 011 (onboarding-hardening), 012 (waitlist 제거)
+- 후속 후보: 서버 측 admin 라우트 middleware 보강 (별도 트랙)

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,0 +1,5 @@
+import LoginPageClient from "@/components/LoginPageClient";
+
+export default function AdminLoginPage() {
+  return <LoginPageClient />;
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -3,18 +3,17 @@
 import { useAuth } from "@/contexts/AuthContext";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
-import LoginForm from "@/components/LoginForm";
+import Dashboard from "@/components/Dashboard";
 
-export default function LoginPageClient() {
+export default function AdminPage() {
   const { user, loading } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
-    // Redirect to admin dashboard if user is already logged in
-    if (user) {
-      router.push("/admin");
+    if (!loading && !user) {
+      router.push("/admin/login");
     }
-  }, [user, router]);
+  }, [user, loading, router]);
 
   if (loading) {
     return (
@@ -27,10 +26,9 @@ export default function LoginPageClient() {
     );
   }
 
-  // Don't show login form if user is authenticated (they'll be redirected)
-  if (user) {
+  if (!user) {
     return null;
   }
 
-  return <LoginForm />;
+  return <Dashboard />;
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,6 @@
-import LoginPageClient from "@/components/LoginPageClient";
+import { redirect } from "next/navigation";
 
-export default function LoginPage() {
-  return <LoginPageClient />;
+// Compatibility redirect — admin login moved to /admin/login (issue #50).
+export default function LegacyLoginPage(): never {
+  redirect("/admin/login");
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,28 +1,5 @@
-"use client";
-
-import { useAuth } from "@/contexts/AuthContext";
 import LandingPage from "@/components/LandingPage";
-import Dashboard from "@/components/Dashboard";
 
 export default function Home() {
-  const { user, loading } = useAuth();
-
-  if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
-          <p className="mt-4 text-gray-600">Loading MyResend...</p>
-        </div>
-      </div>
-    );
-  }
-
-  // Show dashboard if user is authenticated
-  if (user) {
-    return <Dashboard />;
-  }
-
-  // Show landing page for unauthenticated users
   return <LandingPage />;
 }

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -52,7 +52,7 @@ export default function LandingPage() {
                 <span className="hidden sm:inline">GitHub</span>
               </a>
               <Link
-                href="/login"
+                href="/admin"
                 className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors flex items-center space-x-2"
               >
                 <span>Get Started</span>
@@ -88,7 +88,7 @@ export default function LandingPage() {
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
             <Link
-              href="/login"
+              href="/admin"
               className="bg-blue-600 text-white px-8 py-4 rounded-lg hover:bg-blue-700 transition-colors flex items-center justify-center space-x-2 font-semibold"
             >
               <span>Get Started</span>
@@ -377,7 +377,7 @@ export default function LandingPage() {
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Link
-              href="/login"
+              href="/admin"
               className="bg-white text-blue-600 px-8 py-4 rounded-lg hover:bg-gray-100 transition-colors flex items-center justify-center space-x-2 font-semibold"
             >
               <span>Get Started</span>

--- a/src/components/__tests__/LandingPage.test.tsx
+++ b/src/components/__tests__/LandingPage.test.tsx
@@ -54,17 +54,16 @@ describe('LandingPage', () => {
     });
   });
 
-  it('has correct CTA flow directing new operators to login', () => {
+  it('has correct CTA flow directing new operators to the admin area', () => {
     render(<LandingPage />);
 
-    // After the CTA dedupe the page surfaces one primary CTA in the
-    // header and one in the hero — both Get Started buttons route to
-    // /login. There is no longer a standalone "Login" text link, no
-    // "Login here" affordance, and no hero "View on GitHub" duplicate.
+    // Primary "Get Started" CTAs (header + hero + bottom CTA section) route
+    // to /admin — the admin route itself handles the auth gate and bounces
+    // unauthenticated visitors to /admin/login.
     const getStartedLinks = screen.getAllByRole('link', { name: /get started/i });
     expect(getStartedLinks.length).toBeGreaterThanOrEqual(2);
     getStartedLinks.forEach((link) => {
-      expect(link).toHaveAttribute('href', '/login');
+      expect(link).toHaveAttribute('href', '/admin');
     });
 
     expect(screen.getByRole('link', { name: /see pricing/i })).toHaveAttribute('href', '/pricing');


### PR DESCRIPTION
Closes #50.

## Summary
- Move the auth-gated UI from a runtime auth branch on \`/\` into a dedicated \`/admin\` (and \`/admin/login\`) namespace.
- \`/\` now always renders \`<LandingPage />\` for every visitor; the dashboard lives at \`/admin\`.
- Old \`/login\` URL keeps working via a permanent redirect to \`/admin/login\`.
- Landing CTAs ("Get Started") point at \`/admin\` — the admin route itself bounces unauthenticated visitors through the login form.

## Why

Today the app does this on \`/\`:

\`\`\`tsx
if (user)   return <Dashboard />;
            return <LandingPage />;
\`\`\`

That is upstream \`freeresend\`'s "one app does both" design — the same instance served the hosted-SaaS marketing funnel **and** the admin dashboard. After the waitlist (#41) and Hosted-tier (#41) sweeps this fork no longer operates as SaaS, but the structural conflation remained: the operator's own infra promotes the product to itself, and there is no clean URL boundary between "public marketing surface" and "admin tool".

Option B (chosen): keep the calculator / marketing surface, split admin into its own URL space.

| Route | Before | After |
|-------|--------|-------|
| \`/\` | LandingPage (logged out) / Dashboard (logged in) | LandingPage (always) |
| \`/login\` | LoginForm | 308 redirect to \`/admin/login\` |
| \`/pricing\` | Pricing calculator (public) | unchanged |
| \`/admin\` | — (404) | auth gate → \`<Dashboard />\`; otherwise → \`/admin/login\` |
| \`/admin/login\` | — | LoginForm; already-authed visitors redirected to \`/admin\` |

After login → \`/admin\`. After logout → the \`useAuth\` context flips to unauthenticated and the \`/admin\` page automatically bounces back to \`/admin/login\`. No explicit logout-redirect plumbing needed.

## Details

### New routes

- \`src/app/admin/page.tsx\` — client component. Loading spinner during auth check; \`router.push("/admin/login")\` if unauthenticated; otherwise renders the existing \`<Dashboard />\`.
- \`src/app/admin/login/page.tsx\` — thin wrapper that mounts the existing \`<LoginPageClient />\` (which already handles the "already authenticated" redirect; its target is now \`/admin\`).

### \`/\` simplification

\`src/app/page.tsx\` was a 28-line client component with auth-context plumbing and the conditional Dashboard branch. It is now a 5-line server component that just renders \`<LandingPage />\`.

### \`/login\` compatibility

\`src/app/login/page.tsx\` now calls \`redirect("/admin/login")\` from \`next/navigation\`. Any operator who bookmarked \`/login\` or whose docs still pointed there gets a 308 with no work.

### CTAs and docs

- \`LandingPage.tsx\`: three "Get Started" CTAs (header / hero / bottom call-to-action) now point at \`/admin\`. Visitors who happen to already be authenticated skip the login form.
- \`SETUP.md\` / \`SETUP.ko.md\` § 4 step 1: visit \`http://localhost:3000/admin\` (not the root).
- \`LandingPage.test.tsx\`: assert Get Started CTAs route to \`/admin\`.

### Unchanged

- \`<Dashboard />\`, \`<LandingPage />\`, \`<LoginForm />\`, \`<PricingCalculator />\` component bodies.
- All API routes (\`/api/auth/*\`, \`/api/emails\`, \`/api/setup\`, etc.).
- \`/pricing\` route and the calculator UI.
- \`AuthContext\` (\`login\` / \`logout\` still just toggle state — destination redirects are handled at the route layer).

## Changes

\`\`\`
docs/plan/
└── 013-admin-route-split.md                     # NEW — design + decision log + revert path
src/app/
├── page.tsx                                     # simplified: always <LandingPage />
├── login/
│   └── page.tsx                                 # redirect → /admin/login
└── admin/                                       # NEW
    ├── page.tsx                                 # NEW — auth gate + <Dashboard />
    └── login/
        └── page.tsx                             # NEW — <LoginPageClient />
src/components/
├── LandingPage.tsx                              # 3 CTAs: /login → /admin
├── LoginPageClient.tsx                          # router.push("/") → "/admin"
└── __tests__/
    └── LandingPage.test.tsx                     # assert /admin routing
SETUP.md / SETUP.ko.md                           # § 4 step 1: /admin
\`\`\`

## Commits
- [\`f4c0554\`](https://github.com/Orchemi/my-resend/commit/f4c0554) docs(plan): add 013 plan for the /admin route split
- [\`8b8d80d\`](https://github.com/Orchemi/my-resend/commit/8b8d80d) feat(admin): add /admin and /admin/login routes for the auth-gated UI
- [\`46865c6\`](https://github.com/Orchemi/my-resend/commit/46865c6) refactor(home): / is always the public landing, /login redirects to /admin/login

## Verification

\`\`\`
npm run lint        ✓ no warnings
npm run typecheck   ✓ 0 errors (after clearing .next once for stale route types)
npm test --runInBand
                    ✓ 131 / 131 (13 suites)
npm run build       ✓ — /admin and /admin/login appear; /login present as a redirect entry; /pricing unchanged
\`\`\`

## Restore strategy

Mechanical to revert if the split turns out to be wrong:

- \`git revert -m 1 <merge-commit>\` of this PR; **or**
- Move \`src/app/admin/page.tsx\` body back into \`src/app/page.tsx\` (the auth-conditional render is the original code), restore the \`src/app/login/page.tsx\` LoginPageClient mount, drop the CTA href changes.

## Out of scope

- Server-side \`middleware.ts\` admin guard — current client-side \`useAuth\` redirect is sufficient for single-admin OSS. Server middleware is a separate hardening track.
- Renaming or restructuring \`/pricing\`.
- Removing or rewording the landing-page marketing copy.
- Password reset / forgot password — separate concern; today the recovery path is "edit \`.env.local\` + re-run setup".